### PR TITLE
GD-9: Fix SceneRunnerTest

### DIFF
--- a/TestRunner.cs
+++ b/TestRunner.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using GdUnit4.Executions;
 using GdUnit4.Core;
@@ -86,6 +85,7 @@ namespace GdUnit4
         {
             var cmdArgs = Godot.OS.GetCmdlineArgs();
             Console.ForegroundColor = ConsoleColor.White;
+            // TODO check this line, it results into a crash when resizing the terminal
             Console.BufferHeight = 100;
             Console.Clear();
             Console.Title = "GdUnit4TestRunner";

--- a/TestRunner.cs
+++ b/TestRunner.cs
@@ -80,7 +80,7 @@ namespace GdUnit4
 
     partial class TestRunner : Godot.Node
     {
-        private bool FailFast { get; set; } = true;
+        private bool FailFast { get; set; } = false;
 
         public override async void _Ready()
         {
@@ -91,7 +91,7 @@ namespace GdUnit4
             Console.Title = "GdUnit4TestRunner";
             Console.WriteLine($"This is From Console App {Assembly.GetExecutingAssembly()}");
 
-            var currentDir = Directory.GetCurrentDirectory() + "/test/core";
+            var currentDir = Directory.GetCurrentDirectory() + "/test";
             List<TestSuite> testSuites = ScanTestSuites(new DirectoryInfo(currentDir), new List<TestSuite>());
             using Executor executor = new Executor();
             TestReporter listener = new TestReporter();
@@ -99,8 +99,8 @@ namespace GdUnit4
 
             foreach (var testSuite in testSuites)
             {
-                if (!testSuite.Name.Equals("SceneRunnerTest"))
-                    continue;
+                //if (!testSuite.Name.Equals("SceneRunnerTest"))
+                //    continue;
                 await executor.ExecuteInternally(testSuite);
                 if (listener.Failed && FailFast)
                     break;

--- a/src/Assertions.cs
+++ b/src/Assertions.cs
@@ -158,11 +158,13 @@ namespace GdUnit4
         }
 
         /// <summary>
-        /// An Assertion to verify for expecting exceptions
+        /// Asserts that an exception of type <see cref="Exception"/> is thrown when executing the supplied action.
         /// </summary>
-        /// <param name="supplier">A function callback where throw possible exceptions</param>
-        /// <returns>IExceptionAssert</returns>
-        public static IExceptionAssert AssertThrown<T>(Func<T> supplier) => new ExceptionAssert<T>(supplier);
+        /// <param name="action">An action that may throw an exception.</param>
+        /// <returns>An instance of <see cref="IExceptionAssert"/> for further assertions on the thrown exception.</returns>
+        public static IExceptionAssert AssertThrown(Action action) =>
+            new ExceptionAssert<Exception>(action);
+
 
         /// <summary>
         /// An Assertion to verify for expecting exceptions when performing a task.

--- a/src/ISceneRunner.cs
+++ b/src/ISceneRunner.cs
@@ -12,7 +12,7 @@ namespace GdUnit4
     {
         private static SceneTree? _instance = Engine.GetMainLoop() as SceneTree;
 
-        public static SceneTree Instance
+        internal static SceneTree Instance
         {
             get => _instance ?? throw new Exception("SceneTree not set");
         }

--- a/src/ISceneRunner.cs
+++ b/src/ISceneRunner.cs
@@ -10,6 +10,18 @@ namespace GdUnit4
     /// </summary>
     public interface ISceneRunner : IDisposable
     {
+        private static SceneTree? _instance = Engine.GetMainLoop() as SceneTree;
+
+        public static SceneTree Instance
+        {
+            get => _instance ?? throw new Exception("SceneTree not set");
+        }
+
+        public static SignalAwaiter SyncProcessFrame =>
+            Instance.ToSignal(Instance, SceneTree.SignalName.ProcessFrame);
+
+        public static SignalAwaiter SyncPhysicsFrame =>
+            Instance.ToSignal(Instance, SceneTree.SignalName.PhysicsFrame);
 
         /// <summary>
         /// Loads a scene into the SceneRunner to be simmulated.
@@ -143,7 +155,7 @@ namespace GdUnit4
         /// <typeparam name="V">The expected result type</typeparam>
         /// <param name="methodName">The name of the method to wait</param>
         /// <returns>GodotMethodAwaiter</returns>
-        GdUnitAwaiter.GodotMethodAwaiter<V> AwaitMethod<V>(string methodName);
+        GdUnitAwaiter.GodotMethodAwaiter<V> AwaitMethod<[Godot.MustBeVariant] V>(string methodName);
 
         /// <summary>
         /// Waits for given signal is emited.
@@ -156,7 +168,7 @@ namespace GdUnit4
         /// </summary>
         /// <param name="signal">The name of the signal to wait</param>
         /// <returns>Task to wait</returns>
-        Task AwaitSignal(string signal, params object[] args);
+        Task AwaitSignal(string signal, params Godot.Variant[] args);
 
         /// <summary>
         /// Waits for a specific amount of milliseconds.
@@ -192,13 +204,28 @@ namespace GdUnit4
         public Variant Invoke(string name, params Variant[] args);
 
         /// <summary>
-        /// Returns the property by given name.
+        /// Returns the value of the property with the specified name.
         /// </summary>
-        /// <typeparam name="T">The type of the property</typeparam>
-        /// <param name="name">The parameter name</param>
-        /// <returns>The value of the property or throws a MissingFieldException</returns>
-        /// <exception cref="MissingFieldException"/>
-        public T GetProperty<T>(string name);
+        /// <param name="name">The name of the property.</param>
+        /// <returns>The value of the property.</returns>
+        /// <exception cref="MissingFieldException">Thrown when the property is not found.</exception>
+        public dynamic? GetProperty(string name);
+
+        /// <summary>
+        /// Returns the value of the property with the specified name.
+        /// </summary>
+        /// <typeparam name="T">The type of the property value.</typeparam>
+        /// <param name="name">The name of the property.</param>
+        /// <returns>The value of the property.</returns>
+        /// <exception cref="MissingFieldException">Thrown when the property is not found.</exception>
+        public T? GetProperty<T>(string name);
+
+        /// <summary>
+        /// Sets the value of the property with the specified name.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="value">The value to set for the property.</param>
+        public void SetProperty(string name, Godot.Variant value);
 
         /// <summary>
         /// Finds the node by given name.

--- a/src/ISceneRunner.cs
+++ b/src/ISceneRunner.cs
@@ -17,9 +17,16 @@ namespace GdUnit4
             get => _instance ?? throw new Exception("SceneTree not set");
         }
 
+        /// <summary>
+        /// A utility to synchronize the current thread with the Godot physics thread.
+        /// This can be used to await the completion of a single physics frame in Godot.
+        /// </summary>
         public static SignalAwaiter SyncProcessFrame =>
             Instance.ToSignal(Instance, SceneTree.SignalName.ProcessFrame);
 
+        /// <summary>
+        /// A util to syncronize the current thread with the Godot physics thread
+        /// </summary>
         public static SignalAwaiter SyncPhysicsFrame =>
             Instance.ToSignal(Instance, SceneTree.SignalName.PhysicsFrame);
 

--- a/src/asserts/ExceptionAssert.cs
+++ b/src/asserts/ExceptionAssert.cs
@@ -10,9 +10,9 @@ namespace GdUnit4.Asserts
 
         private string? CustomFailureMessage { get; set; }
 
-        public ExceptionAssert(Func<T> supplier)
+        public ExceptionAssert(Action action)
         {
-            try { supplier.Invoke(); }
+            try { action.Invoke(); }
             catch (Exception e) { Current = e; }
         }
 

--- a/src/core/GdUnitConsole.cs
+++ b/src/core/GdUnitConsole.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 
 namespace GdUnit4.Core
@@ -14,6 +15,8 @@ namespace GdUnit4.Core
         private const String __CSI_UNDERLINE = "\u001b[4m";
 
         static object lockObj = new object();
+
+        internal Dictionary<string, (int Left, int Top)> SavedCursors = new Dictionary<string, (int, int)>();
 
         public GdUnitConsole NewLine()
         {
@@ -109,6 +112,18 @@ namespace GdUnit4.Core
         {
             Console.WriteLine(message);
             return this;
+        }
+
+        internal void SaveCursor(string name) =>
+            SavedCursors[name] = Console.GetCursorPosition();
+
+        internal void RestoreCursor(string name)
+        {
+            if (SavedCursors.TryGetValue(name, out var position))
+            {
+                Console.SetCursorPosition(position.Left, position.Top);
+                SavedCursors.Remove(name);
+            }
         }
     }
 }

--- a/src/core/SceneRunner.cs
+++ b/src/core/SceneRunner.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Diagnostics;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 
 namespace GdUnit4
 {
-    using Asserts;
     using Executions;
     using Godot;
     using static Assertions;

--- a/src/core/execution/ExecutionContext.cs
+++ b/src/core/execution/ExecutionContext.cs
@@ -163,7 +163,11 @@ namespace GdUnit4.Executions
 
         public void Dispose()
         {
-            Disposables.ForEach(disposable => disposable.Dispose());
+            Disposables.ForEach(disposable =>
+            {
+                try { disposable.Dispose(); }
+                catch (ObjectDisposedException e) { _ = e; }
+            });
             Stopwatch.Stop();
         }
 

--- a/src/core/exensions/GodotObjectExtension.cs
+++ b/src/core/exensions/GodotObjectExtension.cs
@@ -177,6 +177,8 @@ namespace GdUnit4
                 return sn.ToString();
             if (value is Godot.Collections.Dictionary gd)
                 return gd.UnboxVariant();
+            if (value is Godot.Collections.Array ga)
+                return ga.UnboxVariant();
             return value;
         }
 
@@ -185,6 +187,14 @@ namespace GdUnit4
             var unboxed = new Dictionary<object, object?>();
             foreach (KeyValuePair<Variant, Variant> kvp in dict)
                 unboxed.Add(kvp.Key.UnboxVariant()!, kvp.Value.UnboxVariant());
+            return unboxed;
+        }
+
+        private static ICollection<object?> UnboxVariant(this Godot.Collections.Array values)
+        {
+            var unboxed = new List<object?>();
+            foreach (Variant value in values)
+                unboxed.Add(value.UnboxVariant());
             return unboxed;
         }
 

--- a/test/core/resources/scenes/Spell.gd
+++ b/test/core/resources/scenes/Spell.gd
@@ -10,8 +10,6 @@ var _spell_fired :bool = false
 var _spell_live_time :float = 0
 var _spell_pos :Vector3 = Vector3.ZERO
 
-# helper counter for testing simulate_frames
-var _debug_process_counted := 0
 
 func _ready():
 	set_name("Spell")

--- a/test/core/resources/scenes/TestScene.gd
+++ b/test/core/resources/scenes/TestScene.gd
@@ -1,5 +1,6 @@
 extends Control
 
+
 signal panel_color_change(box, color)
 
 const COLOR_CYCLE := [Color.ROYAL_BLUE, Color.CHARTREUSE, Color.YELLOW_GREEN]
@@ -11,6 +12,7 @@ const COLOR_CYCLE := [Color.ROYAL_BLUE, Color.CHARTREUSE, Color.YELLOW_GREEN]
 @warning_ignore("unused_private_class_variable")
 @export var _initial_color := Color.RED
 
+@warning_ignore("unused_private_class_variable")
 var _nullable :Object
 
 func _ready():
@@ -60,16 +62,16 @@ func _on_timeout(timer :Timer):
 
 
 func color_cycle() -> String:
-	prints("color_cycle")
+	prints("color_cycle initial")
 	await create_timer(0.500).timeout
 	emit_signal("panel_color_change", _box1, Color.RED)
-	prints("timer1")
+	prints("changed to RED")
 	await create_timer(0.500).timeout
 	emit_signal("panel_color_change", _box1, Color.BLUE)
-	prints("timer2")
+	prints("changed to BLUE")
 	await create_timer(0.500).timeout
 	emit_signal("panel_color_change", _box1, Color.GREEN)
-	prints("cycle end")
+	prints("chaned to GREEN")
 	return "black"
 
 


### PR DESCRIPTION
# Why
the test is broken at differnt scenarios and needs to be fixed


# What
- Fix `GetProperty` to handle null values
- Add missing `SetProperty`
- Add `SyncProcessFrame` and `SyncPhysicsFrame` to join the Godot process
- Fix broken `AwaitSignal`
- Fix `GodotMethodAwaiter` to wait a function call is finished
- Add missing `FindChild`
- Extend `ExceptionAssert` to handle method calls with no return values
- better console outputt
- Fix Execution context to handle already disposed objects