### PR TITLE
Prepare GdUnit4Mono 4.2.0.0 release candidate

### DIFF
--- a/api/gdUnit4MonoApi.csproj
+++ b/api/gdUnit4MonoApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.1.0">
+<Project Sdk="Godot.NET.Sdk/4.1.2">
   <PropertyGroup>
     <Title>GdUnit4Mono</Title>
     <Version>4.2.0.0</Version>
@@ -12,6 +12,7 @@
     <LangVersion>11.0</LangVersion>
     <!--Force nullable warnings, you can disable if you want-->
     <Nullable>enable</Nullable>
+    <NullableReferenceTypes>true</NullableReferenceTypes>
     <AssemblyName>GdUnit4MonoApi</AssemblyName>
     <RootNamespace>GdUnit4</RootNamespace>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -24,12 +25,15 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/MikeSchulze/gdUnit4Mono</PackageProjectUrl>
     <PackageId>GdUnit4MonoApi</PackageId>
-    <PackageVersion>4.2.0-release.$([System.DateTime]::Now.ToString('yyyyMMddHHmm'))</PackageVersion>
+    <PackageVersion>4.2.0-rc.$([System.DateTime]::Now.ToString('yyyyMMddHHmm'))</PackageVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>GdUnit4Mono release.</PackageReleaseNotes>
+    <PackageReleaseNotes>GdUnit4Mono release candidate.</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
     <PackageTags>Godot;Test;Testing;UnitTest;GdUnit4;Utility;Utilities</PackageTags>
+    <Description>
+      GdUnit4MonoApi is the C# extention to enable GdUnit4 to run/write unit tests in C#.
+    </Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/api/src/Assertions.cs
+++ b/api/src/Assertions.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 namespace GdUnit4
 {
+    using System.Diagnostics.CodeAnalysis;
     using Asserts;
 
     /// <summary>

--- a/api/src/CsNode.cs
+++ b/api/src/CsNode.cs
@@ -8,6 +8,9 @@ namespace GdUnit4
 
         public string ResourcePath() => _resourcePath;
 
+        // wraper method to GdScript
+        public Godot.Collections.Array<string> TestCaseNames() => ParameterizedTests.ToGodotArray<string>();
+
         public int LineNumber
         { get; private set; } = -1;
 

--- a/api/src/GdUnit4MonoAPI.cs
+++ b/api/src/GdUnit4MonoAPI.cs
@@ -40,5 +40,7 @@ namespace GdUnit4
                 TestCaseAttribute testCaseAttribute = mi.GetCustomAttribute<TestCaseAttribute>()!;
                 return new GdUnit4.Executions.TestCase(mi, testCaseAttribute.Line);
             });
+
+        public static string Version() => Assembly.GetAssembly(typeof(GdUnit4MonoAPI))!.GetName()!.Version!.ToString();
     }
 }

--- a/api/src/IExecutor.cs
+++ b/api/src/IExecutor.cs
@@ -5,12 +5,17 @@ namespace GdUnit4
 
     public interface IExecutor : IDisposable
     {
+        /// <summary>Checks whether the specified node can be executed by this executor implementation.</summary>
+        public bool IsExecutable(Godot.Node node);
+
         // this method is called form gdScript and can't handle 'Task'
         // we used explicit 'async void' to avoid  'Attempted to convert an unmarshallable managed type to Variant Task'
         public void Execute(CsNode node);
 
 
         public IExecutor AddGdTestEventListener(Godot.GodotObject listener);
+
+
 
     }
 }

--- a/api/src/core/GdUnitTestSuiteBuilder.cs
+++ b/api/src/core/GdUnitTestSuiteBuilder.cs
@@ -106,8 +106,6 @@ namespace GdUnit4.Core
                 Name = name;
             }
 
-
-
             public string? Namespace { get; }
             public string Name { get; }
             public string ClassName => Namespace == null ? Name : $"{Namespace}.{Name}";
@@ -215,14 +213,13 @@ namespace GdUnit4.Core
                                 if (attr.Arguments == null || attr.Arguments.Length == 0)
                                     return null;
 
-                                // needs to investigate to use Roslyn analyzer to verify the Attribute matches with the method signature
-                                if (attr.Arguments.Length != mi.GetParameters().Count())
-                                {
-                                }
-                                var testCaseName = mi.Name;
+                                // TODO: needs to investigate to use Roslyn analyzer to verify the Attribute matches with the method signature
+                                //if (attr.Arguments.Length != mi.GetParameters().Count())
+                                //{
+                                //}
                                 if (attr.TestName != null)
                                     return attr.TestName;
-                                return $"{testCaseName} [{attr.Arguments.Formated()}]";
+                                return $"{attr.TestName ?? mi.Name}:{Index} [{attr.Arguments.Formated()}]";
                             })
                             .Where(attr => attr != null)
                             .Aggregate(new List<string>(), (acc, attributes) =>

--- a/api/src/core/attributes/TestCaseAttributes.cs
+++ b/api/src/core/attributes/TestCaseAttributes.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace GdUnit4
 {
@@ -18,14 +19,14 @@ namespace GdUnit4
         /// <summary>
         /// Holds the test case argument when is specified
         /// </summary>
-        internal object[] Arguments { get; set; } = { };
+        internal object?[] Arguments { get; set; } = Array.Empty<object?>();
 
         /// <summary>
         /// Optional test case name to override the original test case name
         /// </summary>
         public string? TestName { get; set; } = null;
 
-        public TestCaseAttribute(params object[] args) : base("", -1)
+        public TestCaseAttribute(params object?[] args) : base("", -1)
         {
             Arguments = args;
         }

--- a/api/src/core/execution/ExecutionContext.cs
+++ b/api/src/core/execution/ExecutionContext.cs
@@ -28,7 +28,7 @@ namespace GdUnit4.Executions
             Disposables = new List<IDisposable>();
         }
 
-        public ExecutionContext(ExecutionContext context, params object[] methodArguments) : this(context.TestSuite, context.EventListeners, context.ReportOrphanNodesEnabled)
+        public ExecutionContext(ExecutionContext context, params object?[] methodArguments) : this(context.TestSuite, context.EventListeners, context.ReportOrphanNodesEnabled)
         {
             ReportCollector = context.ReportCollector;
             context.SubExecutionContexts.Add(this);
@@ -48,12 +48,12 @@ namespace GdUnit4.Executions
             IsSkipped = CurrentTestCase?.IsSkipped ?? false;
         }
 
-        public ExecutionContext(ExecutionContext context, TestCase testCase, TestCaseAttribute testCaseAttribute) : this(context.TestSuite, context.EventListeners, context.ReportOrphanNodesEnabled)
+        public ExecutionContext(ExecutionContext context, TestCase testCase, int testIndex, TestCaseAttribute testCaseAttribute) : this(context.TestSuite, context.EventListeners, context.ReportOrphanNodesEnabled)
         {
             context.SubExecutionContexts.Add(this);
-            TestCaseName = BuildTestCaseName(testCase.Name, testCaseAttribute);
             CurrentTestCase = testCase;
-            CurrentIteration = CurrentTestCase?.TestCaseAttributes.Count() == 1 ? CurrentTestCase?.TestCaseAttributes.ElementAt(0).Iterations ?? 0 : 0;
+            CurrentIteration = 0;
+            TestCaseName = BuildTestCaseName(testCase.Name, testIndex, testCaseAttribute);
             IsSkipped = CurrentTestCase?.IsSkipped ?? false;
         }
 
@@ -92,7 +92,7 @@ namespace GdUnit4.Executions
         public string TestCaseName
         { get; set; } = "";
 
-        public object[] MethodArguments { get; private set; } = { };
+        public object?[] MethodArguments { get; private set; } = Array.Empty<object?>();
 
         private long Duration => Stopwatch.ElapsedMilliseconds;
 
@@ -171,10 +171,10 @@ namespace GdUnit4.Executions
             Stopwatch.Stop();
         }
 
-        private static string BuildTestCaseName(string testName, TestCaseAttribute attribute)
+        private static string BuildTestCaseName(string testName, int index, TestCaseAttribute attribute)
         {
-            if (attribute.Arguments.Count() > 1)
-                return attribute.TestName != null ? attribute.TestName : $"{testName} [{attribute.Arguments.Formated()}]";
+            if (attribute.Arguments.Length > 1)
+                return $"{attribute.TestName ?? testName}:{index} [{attribute.Arguments.Formated()}]";
             return testName;
         }
 

--- a/api/src/core/execution/Executor.cs
+++ b/api/src/core/execution/Executor.cs
@@ -37,6 +37,9 @@ namespace GdUnit4.Executions
 
         public bool ReportOrphanNodesEnabled { get; set; } = true;
 
+        public bool IsExecutable(Godot.Node node) => node is CsNode;
+
+
         /// <summary>
         /// Execute a testsuite, is called externally from Godot test suite runner
         /// </summary>
@@ -69,12 +72,10 @@ namespace GdUnit4.Executions
             try
             {
                 await ISceneRunner.SyncProcessFrame;
-                using (ExecutionContext context = new ExecutionContext(testSuite, _eventListeners, ReportOrphanNodesEnabled))
-                {
-                    var task = new TestSuiteExecutionStage(testSuite).Execute(context);
-                    task.GetAwaiter().OnCompleted(() => EmitSignal(SignalName.ExecutionCompleted));
-                    await task;
-                }
+                using ExecutionContext context = new(testSuite, _eventListeners, ReportOrphanNodesEnabled);
+                var task = new TestSuiteExecutionStage(testSuite).Execute(context);
+                task.GetAwaiter().OnCompleted(() => EmitSignal(SignalName.ExecutionCompleted));
+                await task;
             }
             catch (Exception e)
             {

--- a/api/src/core/exensions/GdUnitExtensions.cs
+++ b/api/src/core/exensions/GdUnitExtensions.cs
@@ -39,7 +39,7 @@ namespace GdUnit4
         public static string Formated(this Godot.Variant value) => value.ToString();
         public static string Formated(this Godot.Variant[] args, int indentation = 0) => string.Join(", ", args.Cast<Godot.Variant>().Select(v => v.Formated())).Indentation(indentation);
         public static string Formated(this Godot.Collections.Array args, int indentation = 0) => args.Cast<IEnumerable>().Formated(indentation);
-        public static string Formated(this object[] args, int indentation = 0) => string.Join(", ", args.ToArray().Select(Formated)).Indentation(indentation);
+        public static string Formated(this object?[] args, int indentation = 0) => string.Join(", ", args.ToArray().Select(Formated)).Indentation(indentation);
         public static string Formated(this IEnumerable args, int indentation = 0) => string.Join(", ", args.Cast<object>().Select(Formated)).Indentation(indentation);
 
         public static string UnixFormat(this string value) => value.Replace("\r", string.Empty);

--- a/gdUnit4Mono.csproj
+++ b/gdUnit4Mono.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Godot.NET.Sdk/4.1.0">
+<Project Sdk="Godot.NET.Sdk/4.1.2">
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>11.0</LangVersion>
     <!--Force nullable warnings, you can disable if you want-->
     <Nullable>enable</Nullable>

--- a/test/gdUnit4MonoTest.csproj
+++ b/test/gdUnit4MonoTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.1.0">
+<Project Sdk="Godot.NET.Sdk/4.1.2">
     <PropertyGroup>
         <Version>4.2.0</Version>
         <Copyright>© 2023 Mike Schulze</Copyright>
@@ -6,6 +6,8 @@
 
         <TargetFramework>net7.0</TargetFramework>
         <LangVersion>11.0</LangVersion>
+        <Nullable>enable</Nullable>
+        <NullableReferenceTypes>true</NullableReferenceTypes>
 
         <RootNamespace>GdUnit4</RootNamespace>
         <AssemblyName>GdUnit4MonoTest</AssemblyName>

--- a/test/src/AssertionsTest.cs
+++ b/test/src/AssertionsTest.cs
@@ -95,7 +95,7 @@ namespace GdUnit4.Tests
         [TestCase]
         public void AutoFree_OnNull()
         {
-            Godot.Node? obj = AutoFree((Godot.Node)null!);
+            Godot.Node? obj = AutoFree((Node)null!);
             AssertThat(obj).IsNull();
         }
     }

--- a/test/src/api/TestRunner.cs
+++ b/test/src/api/TestRunner.cs
@@ -103,7 +103,7 @@ namespace GdUnit4
 
             foreach (var testSuite in testSuites)
             {
-                //if (!testSuite.Name.Equals("TestEventTest"))
+                //if (!testSuite.Name.Equals("DictionaryAssertTest"))
                 //    continue;
                 await executor.ExecuteInternally(testSuite);
                 if (listener.Failed && FailFast)

--- a/test/src/asserts/EnumerableAssertTest.cs
+++ b/test/src/asserts/EnumerableAssertTest.cs
@@ -5,6 +5,8 @@ namespace GdUnit4.Tests.Asserts
     using Executions;
     using Exceptions;
     using static Assertions;
+    using System.Collections;
+
 
     [TestSuite]
     public partial class EnumerableAssertTest
@@ -756,8 +758,8 @@ namespace GdUnit4.Tests.Asserts
         partial class TestObj : Godot.RefCounted
         {
             string _name;
-            object? _value;
-            object? _x;
+            readonly object? _value;
+            readonly object? _x;
 
             public TestObj(string name, object? value, object? x = null)
             {
@@ -779,8 +781,6 @@ namespace GdUnit4.Tests.Asserts
             public string GetX8() => "x8";
             public string GetX9() => "x9";
         }
-
-
 
         [TestCase]
         public void ExtractV()

--- a/test/src/core/ExecutorTest.cs
+++ b/test/src/core/ExecutorTest.cs
@@ -104,17 +104,19 @@ namespace GdUnit4.Tests
         {
             var expectedEvents = new List<ITuple>();
             expectedEvents.Add(Tuple(TESTCASE_BEFORE, suiteName, testName, 0));
+            var index = 0;
             foreach (var testCaseParam in testCaseParams)
             {
-                string testCaseName = TestCaseName(testName, testCaseParam);
+                string testCaseName = TestCaseName(testName, testCaseParam, index);
                 expectedEvents.Add(Tuple(TESTCASE_BEFORE, suiteName, testCaseName, 0));
                 expectedEvents.Add(Tuple(TESTCASE_AFTER, suiteName, testCaseName, 0));
+                index++;
             }
             expectedEvents.Add(Tuple(TESTCASE_AFTER, suiteName, testName, 0));
             return expectedEvents;
         }
 
-        private static string TestCaseName(string testName, object[] testCaseParam) => $"{testName} [{testCaseParam.Formated()}]";
+        private static string TestCaseName(string testName, object[] testCaseParam, int index) => $"{testName}:{index} [{testCaseParam.Formated()}]";
 
         [TestCase(Description = "Verifies the complete test suite ends with success and no failures are reported.")]
         public async Task Execute_Success()
@@ -665,19 +667,19 @@ namespace GdUnit4.Tests
             AssertEventStates(events).Contains(
                 Tuple(TESTSUITE_BEFORE, "Before", true, false, false, false),
                 Tuple(TESTCASE_BEFORE, "ParameterizedBoolValue", true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 0, false }), true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 1, true }), true, false, false, false),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 0, false }, 0), true, false, false, false),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 1, true }, 1), true, false, false, false),
                 Tuple(TESTCASE_AFTER, "ParameterizedBoolValue", true, false, false, false),
                 Tuple(TESTCASE_BEFORE, "ParameterizedIntValues", true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 1, 2, 3, 6 }), true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 3, 4, 5, 12 }), true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 6, 7, 8, 21 }), true, false, false, false),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 1, 2, 3, 6 }, 0), true, false, false, false),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 3, 4, 5, 12 }, 1), true, false, false, false),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 6, 7, 8, 21 }, 2), true, false, false, false),
                 Tuple(TESTCASE_AFTER, "ParameterizedIntValues", true, false, false, false),
                 // a test with failing test cases
                 Tuple(TESTCASE_BEFORE, "ParameterizedIntValuesFail", true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 1, 2, 3, 6 }), true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 3, 4, 5, 11 }), false, false, true, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 6, 7, 8, 22 }), false, false, true, false),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 1, 2, 3, 6 }, 0), true, false, false, false),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 3, 4, 5, 11 }, 1), false, false, true, false),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 6, 7, 8, 22 }, 2), false, false, true, false),
                 Tuple(TESTCASE_AFTER, "ParameterizedIntValuesFail", false, false, true, false),
                 // test suite is failing
                 Tuple(TESTSUITE_AFTER, "After", false, false, true, false)
@@ -685,19 +687,19 @@ namespace GdUnit4.Tests
 
             AssertReports(events).Contains(
                 Tuple(TESTSUITE_BEFORE, "Before", new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 0, false }), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 1, true }), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 1, 2, 3, 6 }), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 3, 4, 5, 12 }), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 6, 7, 8, 21 }), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 1, 2, 3, 6 }), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 3, 4, 5, 11 }), new List<TestReport>(){
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 0, false }, 0), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 1, true }, 1), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 1, 2, 3, 6 }, 0), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 3, 4, 5, 12 }, 1), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 6, 7, 8, 21 }, 2), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 1, 2, 3, 6 }, 0), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 3, 4, 5, 11 }, 1), new List<TestReport>(){
                     new TestReport(FAILURE, 30, """
                         Expecting be equal:
                             '11' but is '12'
                         """)
                 }),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 6, 7, 8, 22 }), new List<TestReport>(){
+                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 6, 7, 8, 22 }, 2), new List<TestReport>(){
                     new TestReport(FAILURE, 30, """
                         Expecting be equal:
                             '22' but is '21'

--- a/test/src/core/GdUnitTestSuiteBuilderTest.cs
+++ b/test/src/core/GdUnitTestSuiteBuilderTest.cs
@@ -221,7 +221,7 @@ namespace GdUnit4.Core.Tests
                     Tuple("TestBar", 42, new List<string>()),
                     Tuple("Waiting", 48, new List<string>()),
                     Tuple("TestFooBar", 54, new List<string>()),
-                    Tuple("TestCaseArguments", 62, new List<string> { "TestCaseArguments [1, 2, 3, 6]", "TestCaseArguments [3, 4, 5, 12]", "TestCaseArguments [6, 7, 8, 21]" }),
+                    Tuple("TestCaseArguments", 62, new List<string> { "TestCaseArguments:0 [1, 2, 3, 6]", "TestCaseArguments:1 [3, 4, 5, 12]", "TestCaseArguments:2 [6, 7, 8, 21]" }),
                     Tuple("TestCasesWithCustomTestName", 70, new List<string> { "TestCaseA", "TestCaseB", "TestCaseC" }));
         }
     }


### PR DESCRIPTION
- update to Godot.NET.Sdk/4.1.2
- fixed warnings
- fixed parameterized test naming