### PR TITLE
GD-11: Add continue integration tests for pull request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,8 +8,11 @@ assignees: MikeSchulze
 ---
 
 <!-- Please search existing issues for potential duplicates before filing yours:
-https://github.com/MikeSchulze/gdUnit4/issues?q=is%3Aissue
+https://github.com/MikeSchulze/gdUnit4Mono/issues?q=is%3Aissue
 -->
+
+**The used GdUnit4 version:**
+<!-- Specify the GdUnit4 version you have used. -->
 
 **The used Godot version:**
 <!-- Specify commit hash if using non-official build. -->

--- a/.github/actions/godot-install/action.yml
+++ b/.github/actions/godot-install/action.yml
@@ -1,0 +1,88 @@
+name: install-godot-binary
+description: "Installs the Godot Runtime"
+
+inputs:
+  godot-version:
+    description: "The Godot engine version"
+    type: string
+    required: true
+  godot-status-version:
+    description: "The Godot engine status version"
+    type: string
+    required: true
+  godot-mono:
+    required: false
+    type: boolean
+    default: false
+  godot-bin-name:
+    type: string
+    required: true
+  godot-cache-path:
+    type: string
+    required: true
+
+
+runs:
+  using: composite
+  steps:
+
+    - name: "Set Cache Name"
+      shell: bash
+      run: |
+        if ${{inputs.godot-mono == 'true'}}; then
+            echo "CACHE_NAME=${{ runner.OS }}-Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status-version }}_mono" >> "$GITHUB_ENV"
+        else
+            echo "CACHE_NAME=${{ runner.OS }}-Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status-version }}" >> "$GITHUB_ENV"
+        fi
+
+    - name: "Build Cache"
+      uses: actions/cache@v3
+      id: godot-cache-binary
+      with:
+        path: ${{ inputs.godot-cache-path }}
+        key: ${{ env.CACHE_NAME }}
+        restore-keys: ${{ env.CACHE_NAME }}
+
+    - name: "Download and Install Godot ${{ inputs.godot-version }}"
+      if: steps.godot-cache-binary.outputs.cache-hit != 'true'
+      continue-on-error: false
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.godot-cache-path }}
+        chmod 770 ${{ inputs.godot-cache-path }}
+        DIR="$HOME/.config/godot"
+        if [ ! -d "$DIR" ]; then
+          mkdir -p "$DIR"
+          chmod 770 "$DIR"
+        fi
+
+        DOWNLOAD_URL=https://github.com/godotengine/godot-builds/releases/download/${{ inputs.godot-version }}-${{ inputs.godot-status-version }}
+        GODOT_BIN=Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status-version }}_${{ inputs.godot-bin-name }}
+        if ${{inputs.godot-mono == 'true'}}; then
+          GODOT_BIN=Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status-version }}_mono_${{ inputs.godot-bin-name }}
+        fi
+
+        GODOT_PACKAGE=$GODOT_BIN.zip
+        wget $DOWNLOAD_URL/$GODOT_PACKAGE -P ${{ inputs.godot-cache-path }}
+        unzip ${{ inputs.godot-cache-path }}/$GODOT_PACKAGE -d ${{ inputs.godot-cache-path }}
+        rm -rf ${{ inputs.godot-cache-path }}/$GODOT_PACKAGE
+
+        if ${{runner.OS == 'Linux'}}; then
+          echo "Run linux part"
+
+          if ${{inputs.godot-mono == 'true'}}; then
+            mv ${{ inputs.godot-cache-path }}/$GODOT_BIN/* ${{ inputs.godot-cache-path }}
+            rmdir ${{ inputs.godot-cache-path }}/$GODOT_BIN/
+          fi
+
+          mv ${{ inputs.godot-cache-path }}/Godot_v* ${{ inputs.godot-cache-path }}/godot
+          chmod u+x ${{ inputs.godot-cache-path }}/godot
+          echo "${{ inputs.godot-cache-path }}/godot"
+        else
+          echo "Run windows part"
+          pwd
+          mv ${{ inputs.godot-cache-path }}/$GODOT_BIN ${{ inputs.godot-cache-path }}/godot.exe
+          chmod u+x ${{ inputs.godot-cache-path }}/godot.exe
+          ${{ inputs.godot-cache-path }}/godot.exe --version
+          echo "${{ inputs.godot-cache-path }}/godot.exe"
+        fi

--- a/.github/actions/publish-test-report/action.yml
+++ b/.github/actions/publish-test-report/action.yml
@@ -9,8 +9,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Publish Test Results 
-      uses: dorny/test-reporter@v1
+
+    - name: 'Fixing the dubious git 128 error'
+      shell: bash
+      run: |
+        git config --global --add safe.directory '*'
+
+    - name: 'Publish Test Results'
+      uses: dorny/test-reporter@v1.6.0
       with:
         name: test_report_${{ inputs.report-name }}
         path: 'reports/**/results.xml'

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -1,18 +1,25 @@
 name: unit-test
-description: "Run unit tests for GdUnit4 API"
+description: "Runs the unit tests on GdUnit4 API"
 
 inputs:
   test-includes:
-    description: "Paths to include for test run"
+    description: "The path to include tests to be run"
     required: true
   godot-bin:
     required: true
 
 runs:
   using: composite
+
   steps:
-    - name: "Unit Test"
+    - name: "Unit Test Linux"
+      if: ${{ runner.OS == 'Linux' }}
       env:
-        GODOT_BIN: ${{ inputs.godot-bin }}
+        GODOT_BIN: "/home/runner/godot-linux/godot"
       shell: bash
-      run: ./runtest.sh --add ${{ inputs.test-includes }} --continue
+      run: |
+        $GODOT_BIN --path ./test -e --quit
+        $GODOT_BIN --path ./test -d ./src/api/TestRunner.tscn --failfast --add src
+
+      #xvfb-run --auto-servernum ./addons/gdUnit4/runtest.sh --add ${{ inputs.test-includes }} --audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --continue --verbose
+

--- a/.github/actions/upload-test-report/action.yml
+++ b/.github/actions/upload-test-report/action.yml
@@ -10,7 +10,10 @@ runs:
   using: composite
   steps:
     - name: Collect Test Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: test_report_${{ inputs.report-name }}
-        path: reports/**
+        path: |
+          reports/**
+          /var/lib/systemd/coredump/**
+          /var/log/syslog

--- a/.github/actions/workflow-cleanup/index.js
+++ b/.github/actions/workflow-cleanup/index.js
@@ -1,0 +1,102 @@
+const DAYS_TO_EXPIRITION = 5;
+const MS_IN_DAYS = 86400000;
+const DAYS_TO_EXPIRITION_IN_MS = DAYS_TO_EXPIRITION * MS_IN_DAYS;
+
+module.exports = async ({ github, context, core, exec }) => {
+    const now = Date.now();
+    const {
+        repo: { repo, owner }
+    } = context;
+
+    let activeBranches = [];
+    await exec.exec('git', ['branch', '-r', '--list'], {
+        listeners: {
+            stdout: (data) => {
+                activeBranches = activeBranches.concat(
+                    data
+                        .toString()
+                        .split('\n')
+                        .map((branch) => branch.replace('origin/', '').trim())
+                );
+            }
+        }
+    });
+
+    core.info(`Found ${activeBranches.length} active branches`);
+    const filterWorkflowRunsReducer = (
+        acc,
+        { id, head_branch, status, conclusion, created_at, html_url }
+    ) => {
+        // filter skipped and cancelled workflow runs
+        if (status === 'completed' && (conclusion === 'skipped' || conclusion === 'cancelled')) {
+            core.info(
+                `Add run to delete because of status: "${status}" or conclusion: "${conclusion}". Link: ${html_url}`
+            );
+            acc.push(id);
+            return acc;
+        }
+
+        // filter workflow runs of deleted branches
+        if (!activeBranches.includes(head_branch)) {
+            core.info(
+                `Add run to delete because it is not an active branch: "${head_branch}". Link: ${html_url}`
+            );
+            acc.push(id);
+            return acc;
+        }
+
+        // filter workflow runs older than 5 days
+        if (now - Date.parse(created_at) > DAYS_TO_EXPIRITION_IN_MS) {
+            core.info(
+                `Add run to delete because it is expired: "${created_at}". Link: ${html_url}`
+            );
+            acc.push(id);
+            return acc;
+        }
+
+        core.info(`Will not delete run: ${html_url}`);
+        return acc;
+    };
+
+    const deleteWorkflowRun = (run_id) => {
+        core.info(`Attempt to delete workflow run with id: ${run_id}`);
+
+        return github.actions.deleteWorkflowRun({
+            owner,
+            repo,
+            run_id
+        });
+    };
+
+    const pruneWorkflowRuns = async () => {
+        const workflowRuns = await github.paginate(github.actions.listWorkflowRunsForRepo, {
+            owner,
+            repo,
+            per_page: 100
+        });
+
+        const idsToDelete = workflowRuns.reduce(filterWorkflowRunsReducer, []);
+
+        core.info(`Found ${idsToDelete.length} workflow runs that are obsolete`);
+
+        core.startGroup('Delete workflow runs');
+        const responses = await Promise.all(idsToDelete.map(deleteWorkflowRun));
+        core.endGroup();
+
+        return responses;
+    };
+
+    try {
+        const response = await pruneWorkflowRuns();
+        const failed = response.filter(({ status }) => status < 200 || status > 300);
+
+        core.notice(`Deleted ${response.length - failed.length} obsolete workflow runs`);
+        core.notice(`${failed.length} deletion(s) failed`);
+
+        if (failed.length > 0) {
+            console.log(failed);
+        }
+    } catch (e) {
+        core.setFailed(`Action failed with error ${e}`);
+    }
+};

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,4 +1,5 @@
-name: CI-PR
+name: ci-pr
+run-name: ${{ github.head_ref || github.ref_name }}-ci-pr
 
 on:
   pull_request:
@@ -9,87 +10,40 @@ on:
       - '**.md'
   workflow_dispatch:
 
-env:
-  GODOT_BIN: "/usr/local/bin/godot"
 
 concurrency:
   group: ci-pr-${{ github.event.number }}
   cancel-in-progress: true
 
+
 jobs:
-  unit-test:
+  unit-tests:
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix:
-        godot-build: ['mono-']
-        godot-version: [3.3.3, 3.3.4, 3.4.1, 3.4.2, 3.4.4, 3.4.5, 3.5] # 3.4.3 is missing on barichello/godot-ci
+        godot-version: ['4.1', '4.1.1', '4.1.2', '4.1.3', '4.2']
+        godot-status: ['stable']
+#        include:
+#          - godot-version: '4.2'
+#            godot-status: 'beta4'
 
-    name: "CI on Godot ${{ matrix.godot-build }}v${{ matrix.godot-version }}"
+
+    name: "CI on Godot 🐧 v${{ matrix.godot-version }}-${{ matrix.godot-status }}"
+    uses: ./.github/workflows/unit-tests.yml
+    with:
+      godot-version: ${{ matrix.godot-version }}
+      godot-status: ${{ matrix.godot-status }}
+
+  finalize:
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    timeout-minutes: 6
-    continue-on-error: false
-    container:
-      image: barichello/godot-ci:${{ matrix.godot-build }}${{ matrix.godot-version }}
-
+    name: Final Results
+    needs: [unit-tests]
     steps:
-      - name: "Checkout GdUnit4 Plugin"
-        if: ${{ !cancelled() }}
-        uses: actions/checkout@v3
-        with:
-          repository: MikeSchulze/gdUnit4
-
-      - name: "Checkout GdUnit4Mono"
-        if: ${{ !cancelled() }}
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-          path: mono
-
-      - name: "Patch Project"
-        if: ${{ !cancelled() }}
-        run: |
-          rm -rf gdUnit4.csproj
-          rm -rf addons/gdUnit4/test/
-          cp ./mono/gdUnit4Mono.csproj gdUnit4.csproj
-          mv mono/test ./test
-
-        # cp ./mono/gdUnit4Mono.sln gdUnit4.sln
-        # sed -i 's+config/name="gdUnit4"+config/name="gdUnit4Mono"+g' project.godot
-
-      - name: "Setup .NET"
-        if: ${{ !cancelled() }}
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 6.0.x
-
-      - name: "Compile C#"
-        timeout-minutes: 1
-        run: |
-          ${{ env.GODOT_BIN }} project.godot --build-solutions --quit --no-window
-
-      - name: "Update Project"
-        if: ${{ !cancelled() }}
-        timeout-minutes: 1
-        continue-on-error: true # we still ignore the timeout, the script is not quit and we run into a timeout
-        run: |
-          ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit4/src/core/scan_project.gd --no-window
-
-      - name: "Run Unit Test"
-        if: ${{ !cancelled() }}
-        timeout-minutes: 10
-        uses: ./.github/actions/unit-test
-        with:
-          godot-bin: ${{ env.GODOT_BIN }}
-          test-includes: "res://test"
-
-      - name: "Publish Unit Test Reports"
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/publish-test-report
-        with:
-          report-name: ${{ matrix.godot-build }}${{ matrix.godot-version }}
-
-      - name: "Upload Unit Test Reports"
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/upload-test-report
-        with:
-          report-name: ${{ matrix.godot-build }}${{ matrix.godot-version }}
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,91 @@
+name: unit-tests
+run-name: ${{ github.head_ref || github.ref_name }}-unit-tests
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: false
+        type: string
+        default: 'ubuntu-22.04'
+      godot-version:
+        required: true
+        type: string
+      godot-status:
+        required: true
+        type: string
+
+  workflow_dispatch:
+    inputs:
+      os:
+        required: false
+        type: string
+        default: 'ubuntu-22.04'
+      godot-version:
+        required: true
+        type: string
+      godot-status:
+        required: true
+        type: string
+
+concurrency:
+  group: unit-tests-${{ github.head_ref || github.ref_name }}-${{ inputs.godot-version }}
+  cancel-in-progress: true
+
+jobs:
+
+  unit-test:
+    name: "Unit Tests"
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 5
+
+    steps:
+      - name: "Checkout GdUnit Repository"
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: "Install Godot Mono ${{ inputs.godot-version }}"
+        uses: ./.github/actions/godot-install
+        with:
+          godot-version: ${{ inputs.godot-version }}
+          godot-mono: true
+          godot-status-version: ${{ inputs.godot-status }}
+          godot-bin-name: 'linux_x86_64'
+          godot-cache-path: '~/godot-linux'
+
+      - name: "Setup .NET"
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+
+      - name: "Compile C#"
+        if: ${{ !cancelled() }}
+        run: |
+          dotnet restore
+          dotnet build
+
+      - name: "Run Unit Tests"
+        if: ${{ !cancelled() }}
+        timeout-minutes: 5
+        uses: ./.github/actions/unit-test
+        with:
+          godot-bin: '~/godot-linux/godot'
+          test-includes: "res://test/src"
+
+      - name: "Set Report Name"
+        if: ${{ always() }}
+        shell: bash
+        run: echo "REPORT_NAME=${{ inputs.os }}-${{ inputs.godot-version }}-mono" >> "$GITHUB_ENV"
+
+      - name: "Publish Unit Test Reports"
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/publish-test-report
+        with:
+          report-name: ${{ env.REPORT_NAME }}
+
+      - name: "Upload Unit Test Reports"
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/upload-test-report
+        with:
+          report-name: ${{ env.REPORT_NAME }}

--- a/.github/workflows/workflow-cleanup.yml
+++ b/.github/workflows/workflow-cleanup.yml
@@ -1,0 +1,26 @@
+# This workflow prunes old workflow runs for an entire repository.
+
+name: cleanup-workflow-runs
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # GMT
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Cleanup of obsolete workflow runs
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const script = require('./.github/actions/workflow-cleanup/index.js')
+            await script({ github, context, core, exec });

--- a/test/nuget.config
+++ b/test/nuget.config
@@ -3,7 +3,7 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="localhost.gdUnit4.api" value=".\api\bin\Debug\" />
-    <add key="localhost.gdUnit4.test.adapter" value=".\testadapter\bin\Debug\" />
+    <add key="localhost.gdUnit4.api" value="./../api/bin/Debug/" />
+    <add key="localhost.gdUnit4.test.adapter" value="./../testadapter/bin/Debug/" />
   </packageSources>
 </configuration>

--- a/test/project.godot
+++ b/test/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="gdUnit4Test"
 run/main_scene="res://src/api/TestRunner.tscn"
-config/features=PackedStringArray("4.1", "C#", "Forward Plus")
+config/features=PackedStringArray("4.2", "C#", "Forward Plus")
 config/icon="res://icon.svg"
 
 [dotnet]


### PR DESCRIPTION
# Why
We need an automated way to run all tests on a pull request.

# What
Enable CI for pull requests.
- install godot
- build the project
- run tests via provides test runner