### PR TITLE
GD-16: Add GdUnit4 Test Adapter to CI Workflow

### DIFF
--- a/.github/actions/publish-test-report/action.yml
+++ b/.github/actions/publish-test-report/action.yml
@@ -19,6 +19,6 @@ runs:
       uses: dorny/test-reporter@v1.6.0
       with:
         name: test_report_${{ inputs.report-name }}
-        path: 'reports/**/results.xml'
-        reporter: java-junit
+        path: 'test/TestResults/test-result.trx'
+        reporter: dotnet-trx
         fail-on-error: 'false'

--- a/.github/actions/upload-test-report/action.yml
+++ b/.github/actions/upload-test-report/action.yml
@@ -14,6 +14,7 @@ runs:
       with:
         name: test_report_${{ inputs.report-name }}
         path: |
+          /test/TestResults/**
           reports/**
           /var/lib/systemd/coredump/**
           /var/log/syslog

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -132,5 +132,8 @@ jobs:
       - name: "Run Unit Tests"
         if: ${{ !cancelled() }}
         timeout-minutes: 5
+        env:
+          GODOT_BIN: "/home/runner/godot-linux/godot"
         run: |
-          echo "TODO Run unit tests by ms test adapter"
+          $GODOT_BIN --path ./test -e --quit --headless
+          xvfb-run --auto-servernum dotnet test ./test/gdUnit4Test.csproj --settings ./test/.runsettings-ci

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -136,4 +136,4 @@ jobs:
           GODOT_BIN: "/home/runner/godot-linux/godot"
         run: |
           $GODOT_BIN --path ./test -e --quit --headless
-          xvfb-run --auto-servernum dotnet test ./test/gdUnit4Test.csproj --settings ./test/.runsettings-ci
+          xvfb-run --auto-servernum dotnet test ./test/gdUnit4Test.csproj --no-build --settings ./test/.runsettings-ci

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -137,3 +137,20 @@ jobs:
         run: |
           $GODOT_BIN --path ./test -e --quit --headless
           xvfb-run --auto-servernum dotnet test ./test/gdUnit4Test.csproj --no-build --settings ./test/.runsettings-ci
+
+      - name: "Set Report Name"
+        if: ${{ always() }}
+        shell: bash
+        run: echo "REPORT_NAME=${{ inputs.os }}-${{ inputs.godot-version }}" >> "$GITHUB_ENV"
+
+      - name: "Publish Unit Test Reports"
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/publish-test-report
+        with:
+          report-name: ${{ env.REPORT_NAME }}
+
+      - name: "Upload Unit Test Reports"
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/upload-test-report
+        with:
+          report-name: ${{ env.REPORT_NAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ bin/
 obj/
 .generated/
 *.*.import
+TestResults/
 
 # Mono-specific ignores
 .mono/

--- a/api/src/core/GdUnitTestSuiteBuilder.cs
+++ b/api/src/core/GdUnitTestSuiteBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GdUnit4.Executions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -215,25 +216,9 @@ namespace GdUnit4.Core
                         // collect testcase if multipe TestCaseAttribute exists
                         var testCases = mi.GetCustomAttributes(typeof(TestCaseAttribute))
                             .Cast<TestCaseAttribute>()
-                            .Select((attr, Index) =>
-                            {
-                                if (attr.Arguments == null || attr.Arguments.Length == 0)
-                                    return null;
-
-                                // TODO: needs to investigate to use Roslyn analyzer to verify the Attribute matches with the method signature
-                                //if (attr.Arguments.Length != mi.GetParameters().Count())
-                                //{
-                                //}
-                                if (attr.TestName != null)
-                                    return attr.TestName;
-                                return $"{attr.TestName ?? mi.Name}:{Index} [{attr.Arguments.Formated()}]";
-                            })
-                            .Where(attr => attr != null)
-                            .Aggregate(new List<string>(), (acc, attributes) =>
-                            {
-                                acc.Add(attributes!);
-                                return acc;
-                            });
+                            .Where(attr => attr != null && (attr.Arguments?.Any() ?? false))
+                            .Select(attr => TestCase.BuildTestCaseName(attr.TestName ?? mi.Name, attr))
+                            .ToList();
                         // create test
                         return new CsNode(mi.Name, classPath, lineNumber, testCases);
                     })

--- a/api/src/core/GdUnitTestSuiteBuilder.cs
+++ b/api/src/core/GdUnitTestSuiteBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -176,7 +177,7 @@ namespace GdUnit4.Core
                 var className = namespaceSyntax != null ? namespaceSyntax!.Name + "." + classDeclaration.Identifier : classDeclaration.Identifier.ValueText;
                 return FindTypeOnAssembly(className);
             }
-            Console.Error.WriteLine($"No class found in the provided code ({classPath}).");
+            Console.WriteLine($"Warning: No class found in the provided code ({classPath}).");
             return null;
         }
 
@@ -184,7 +185,7 @@ namespace GdUnit4.Core
         {
             if (string.IsNullOrEmpty(classPath) || !new FileInfo(classPath).Exists)
             {
-                Console.Error.WriteLine($"Class `{classPath}` does not exist.");
+                Console.WriteLine($"Warning: Class `{classPath}` does not exist.");
                 return null;
             }
             return FindClassWithTestSuiteAttribute(classPath, isTestSuite);

--- a/api/src/core/execution/ExecutionContext.cs
+++ b/api/src/core/execution/ExecutionContext.cs
@@ -47,12 +47,12 @@ namespace GdUnit4.Executions
             IsSkipped = CurrentTestCase?.IsSkipped ?? false;
         }
 
-        public ExecutionContext(ExecutionContext context, TestCase testCase, int testIndex, TestCaseAttribute testCaseAttribute) : this(context.TestSuite, context.EventListeners, context.ReportOrphanNodesEnabled)
+        public ExecutionContext(ExecutionContext context, TestCase testCase, TestCaseAttribute testCaseAttribute) : this(context.TestSuite, context.EventListeners, context.ReportOrphanNodesEnabled)
         {
             context.SubExecutionContexts.Add(this);
             CurrentTestCase = testCase;
             CurrentIteration = 0;
-            TestCaseName = BuildTestCaseName(testCase.Name, testIndex, testCaseAttribute);
+            TestCaseName = TestCase.BuildTestCaseName(testCase.Name, testCaseAttribute);
             IsSkipped = CurrentTestCase?.IsSkipped ?? false;
         }
 
@@ -170,12 +170,7 @@ namespace GdUnit4.Executions
             Stopwatch.Stop();
         }
 
-        private static string BuildTestCaseName(string testName, int index, TestCaseAttribute attribute)
-        {
-            if (attribute.Arguments.Length > 1)
-                return $"{attribute.TestName ?? testName}:{index} [{attribute.Arguments.Formated()}]";
-            return testName;
-        }
+
 
         public void PrintDebug(string name = "")
         {

--- a/api/src/core/execution/ExecutionStage.cs
+++ b/api/src/core/execution/ExecutionStage.cs
@@ -84,22 +84,12 @@ namespace GdUnit4.Executions
 
         private static void ReportAsFailure(ExecutionContext context, TestFailedException e)
         {
-            if (Godot.OS.IsStdOutVerbose())
-            {
-                Godot.GD.PushError(e.Message);
-                Godot.GD.PushError(e.StackTrace);
-            }
             if (context.FailureReporting)
                 context.ReportCollector.Consume(new TestReport(TestReport.TYPE.FAILURE, e.LineNumber, e.Message));
         }
 
         private static void ReportAsException(ExecutionContext context, Exception e)
         {
-            if (Godot.OS.IsStdOutVerbose())
-            {
-                Godot.GD.PushError(e.Message);
-                Godot.GD.PushError(e.StackTrace);
-            }
             StackTrace stack = new StackTrace(e, true);
             var lineNumber = ScanFailureLineNumber(stack);
             context.ReportCollector.Consume(new TestReport(TestReport.TYPE.ABORT, lineNumber, e.Message));

--- a/api/src/core/execution/Executor.cs
+++ b/api/src/core/execution/Executor.cs
@@ -85,9 +85,10 @@ namespace GdUnit4.Executions
                 var task = ExecuteInternally(new TestSuite(testSuite.ResourcePath(), includedTests));
                 task.GetAwaiter().OnCompleted(() => EmitSignal(SignalName.ExecutionCompleted));
             }
+            // handle unexpected exceptions
             catch (Exception e)
             {
-                Godot.GD.PushError(e.Message);
+                Console.Error.WriteLine("Unexpected Exception: %s \nStackTrace: %s", e.Message, e.StackTrace);
             }
             finally
             {
@@ -100,16 +101,15 @@ namespace GdUnit4.Executions
             try
             {
                 if (!ReportOrphanNodesEnabled)
-                    Godot.GD.PushWarning("!!! Reporting orphan nodes is disabled. Please check GdUnit settings.");
+                    Console.WriteLine("Warning!!! Reporting orphan nodes is disabled. Please check GdUnit settings.");
                 await ISceneRunner.SyncProcessFrame;
                 using ExecutionContext context = new(testSuite, _eventListeners, ReportOrphanNodesEnabled);
                 await new TestSuiteExecutionStage(testSuite).Execute(context);
             }
+            // handle unexpected exceptions
             catch (Exception e)
             {
-                // unexpected exceptions
-                Godot.GD.PushError(e.Message);
-                Godot.GD.PushError(e.StackTrace);
+                Console.Error.WriteLine("Unexpected Exception: %s \nStackTrace: %s", e.Message, e.StackTrace);
             }
             finally
             {

--- a/api/src/core/execution/TestCase.cs
+++ b/api/src/core/execution/TestCase.cs
@@ -19,7 +19,9 @@ namespace GdUnit4.Executions
         public int Line
         { get; private set; }
 
-        public IEnumerable<TestCaseAttribute> TestCaseAttributes => MethodInfo.GetCustomAttributes<TestCaseAttribute>();
+        public IEnumerable<TestCaseAttribute> TestCaseAttributes => MethodInfo.GetCustomAttributes<TestCaseAttribute>().Where(TestParametersFilter);
+
+        public Func<TestCaseAttribute, bool> TestParametersFilter { get; set; } = _ => true;
 
         public TestCaseAttribute TestCaseAttribute => MethodInfo.GetCustomAttribute<TestCaseAttribute>()!;
 
@@ -55,6 +57,13 @@ namespace GdUnit4.Executions
         }
 
         public object[] Arguments => Parameters.SelectMany(ResolveParam).ToArray<object>();
+
+        public static string BuildTestCaseName(string testName, TestCaseAttribute attribute)
+        {
+            if (attribute.Arguments.Any())
+                return $"{testName}.{attribute.TestName ?? testName}({attribute.Arguments.Formated()})";
+            return testName;
+        }
 
     }
 }

--- a/api/src/core/execution/TestSuiteExecutionStage.cs
+++ b/api/src/core/execution/TestSuiteExecutionStage.cs
@@ -48,10 +48,9 @@ namespace GdUnit4.Executions
         private async Task RunParameterizedTest(ExecutionContext executionContext, TestCase testCase)
         {
             executionContext.FireBeforeTestEvent();
-            for (int testIndex = 0; testIndex < testCase.TestCaseAttributes.Count(); testIndex++)
+            foreach (var testAttribute in testCase.TestCaseAttributes)
             {
-                var testAttribute = testCase.TestCaseAttributes.ElementAt(testIndex);
-                using ExecutionContext testCaseContext = new(executionContext, testCase, testIndex, testAttribute);
+                using ExecutionContext testCaseContext = new(executionContext, testCase, testAttribute);
                 await RunTestCase(testCaseContext, testCase, testAttribute, testAttribute.Arguments);
             }
             executionContext.FireAfterTestEvent();

--- a/api/src/core/exensions/GdUnitExtensions.cs
+++ b/api/src/core/exensions/GdUnitExtensions.cs
@@ -8,6 +8,7 @@ using GdUnit4.Asserts;
 using System.Threading;
 using System.Diagnostics;
 using GdUnit4.Executions;
+using System.Globalization;
 
 namespace GdUnit4
 {
@@ -28,14 +29,27 @@ namespace GdUnit4
 
         private static string Format(this object? value)
         {
-            if (value is String asString)
-                return asString.Formated();
-            if (value is IEnumerable en)
-                return en.Formated();
-            if (value is Godot.Variant asVariant)
-                return asVariant.Formated();
-
-            return value?.ToString() ?? "<Null>";
+            switch (value)
+            {
+                case string asString:
+                    return asString.Formated();
+                case IEnumerable en:
+                    return en.Formated();
+                case Godot.Variant asVariant:
+                    return asVariant.Formated();
+                case float v:
+                    return v.ToString("G9", CultureInfo.InvariantCulture);
+                case double d:
+                    return d.ToString("G9", CultureInfo.InvariantCulture);
+                case decimal dec:
+                    return dec.ToString("G9", CultureInfo.InvariantCulture);
+                case int i:
+                    return i.ToString(CultureInfo.InvariantCulture);
+                case long l:
+                    return l.ToString(CultureInfo.InvariantCulture);
+                default:
+                    return value?.ToString() ?? "<Null>";
+            }
         }
 
 

--- a/api/src/core/exensions/GdUnitExtensions.cs
+++ b/api/src/core/exensions/GdUnitExtensions.cs
@@ -18,7 +18,6 @@ namespace GdUnit4
     /// </summary>
     public static class GdUnitExtensions
     {
-
         public static string ToSnakeCase(this string? input)
         {
             if (string.IsNullOrEmpty(input))

--- a/test/.runsettings
+++ b/test/.runsettings
@@ -20,6 +20,11 @@
                     <LogFileName>test-result.html</LogFileName>
                 </Configuration>
             </Logger>
+            <Logger friendlyName="trx" enabled="True">
+                <Configuration>
+                    <LogFileName>test-result.trx</LogFileName>
+                </Configuration>
+            </Logger>
         </Loggers>
     </LoggerRunSettings>
 

--- a/test/.runsettings
+++ b/test/.runsettings
@@ -15,6 +15,11 @@
                     <Verbosity>detailed</Verbosity>
                 </Configuration>
             </Logger>
+            <Logger friendlyName="html" enabled="True">
+                <Configuration>
+                    <LogFileName>test-result.html</LogFileName>
+                </Configuration>
+            </Logger>
         </Loggers>
     </LoggerRunSettings>
 
@@ -25,5 +30,8 @@
     <GdUnit4>
         <!-- Additonal Godot runtime parameters-->
         <Parameters></Parameters>
+        <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
+             This likely determines how the test names are displayed in the test results.-->
+        <DisplayName>FullyQualifiedName</DisplayName>
     </GdUnit4>
 </RunSettings>

--- a/test/.runsettings-ci
+++ b/test/.runsettings-ci
@@ -15,11 +15,37 @@
                     <Verbosity>detailed</Verbosity>
                 </Configuration>
             </Logger>
+            <Logger friendlyName="html" enabled="True">
+                <Configuration>
+                    <LogFileName>test-result.html</LogFileName>
+                </Configuration>
+            </Logger>
         </Loggers>
     </LoggerRunSettings>
 
+    <DataCollectionRunSettings>
+        <DataCollectors>
+        <!-- Enables blame -->
+        <DataCollector friendlyName="blame" enabled="True">
+            <Configuration>
+            <!-- Enables crash dump, with dump type "Full" or "Mini".
+            Requires ProcDump in PATH for .NET Framework. -->
+            <CollectDump DumpType="Full" />
+            <!-- Enables hang dump or testhost and its child processes 
+            when a test hangs for more than 10 minutes. 
+            Dump type "Full", "Mini" or "None" (just kill the processes). -->
+            <CollectDumpOnTestSessionHang TestTimeout="10min" HangDumpType="Full" />
+            </Configuration>
+        </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
+
     <GdUnit4>
         <!-- Additonal Godot runtime parameters-->
+        <!-- These parameters are crucial for configuring the Godot runtime to work in headless environments, such as those used in automated testing or CI/CD pipelines.-->        
         <Parameters>--audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --verbose</Parameters>
+        <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
+             This likely determines how the test names are displayed in the test results.-->
+        <DisplayName>FullyQualifiedName</DisplayName>
     </GdUnit4>
 </RunSettings>

--- a/test/.runsettings-ci
+++ b/test/.runsettings-ci
@@ -18,12 +18,8 @@
         </Loggers>
     </LoggerRunSettings>
 
-    <TestRunParameters>
-        <Parameter name="TEST_PARAM" value="test" />
-    </TestRunParameters>
-
     <GdUnit4>
         <!-- Additonal Godot runtime parameters-->
-        <Parameters></Parameters>
+        <Parameters>--audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --verbose</Parameters>
     </GdUnit4>
 </RunSettings>

--- a/test/.runsettings-ci
+++ b/test/.runsettings-ci
@@ -20,6 +20,11 @@
                     <LogFileName>test-result.html</LogFileName>
                 </Configuration>
             </Logger>
+            <Logger friendlyName="trx" enabled="True">
+                <Configuration>
+                    <LogFileName>test-result.trx</LogFileName>
+                </Configuration>
+            </Logger>
         </Loggers>
     </LoggerRunSettings>
 

--- a/test/gdUnit4Test.csproj
+++ b/test/gdUnit4Test.csproj
@@ -18,6 +18,8 @@
         <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+        <!--Disable warning/error of invalid/incompatible GodotSharp version, the package GdUnit4.API is build by V4.2.0-->
+        <NoWarn>NU1605</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/src/core/ExampleTestSuite.cs
+++ b/test/src/core/ExampleTestSuite.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
 
-namespace GdUnit4.Tests.Asserts
+namespace GdUnit4.Tests.Core
 {
     using static Assertions;
     using static Utils;

--- a/test/src/core/ExecutorTest.cs
+++ b/test/src/core/ExecutorTest.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace GdUnit4.Tests
+namespace GdUnit4.Tests.Core
 {
     using GdUnit4.Asserts;
     using Executions;
@@ -109,7 +109,7 @@ namespace GdUnit4.Tests
             var index = 0;
             foreach (var testCaseParam in testCaseParams)
             {
-                string testCaseName = TestCaseName(testName, testCaseParam, index);
+                string testCaseName = ParameterizedTestCaseName(testName, testCaseParam, index);
                 expectedEvents.Add(Tuple(TESTCASE_BEFORE, suiteName, testCaseName, 0));
                 expectedEvents.Add(Tuple(TESTCASE_AFTER, suiteName, testCaseName, 0));
                 index++;
@@ -118,7 +118,7 @@ namespace GdUnit4.Tests
             return expectedEvents;
         }
 
-        private static string TestCaseName(string testName, object[] testCaseParam, int index) => $"{testName}:{index} [{testCaseParam.Formated()}]";
+        private static string ParameterizedTestCaseName(string testName, object[] testCaseParam, int index) => $"{testName}.{testName}({testCaseParam.Formated()})";
 
         [TestCase(Description = "Verifies the complete test suite ends with success and no failures are reported.")]
         public async Task Execute_Success()
@@ -668,19 +668,19 @@ namespace GdUnit4.Tests
             AssertEventStates(events).Contains(
                 Tuple(TESTSUITE_BEFORE, "Before", true, false, false, false),
                 Tuple(TESTCASE_BEFORE, "ParameterizedBoolValue", true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 0, false }, 0), true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 1, true }, 1), true, false, false, false),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedBoolValue", new object[] { 0, false }, 0), true, false, false, false),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedBoolValue", new object[] { 1, true }, 1), true, false, false, false),
                 Tuple(TESTCASE_AFTER, "ParameterizedBoolValue", true, false, false, false),
                 Tuple(TESTCASE_BEFORE, "ParameterizedIntValues", true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 1, 2, 3, 6 }, 0), true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 3, 4, 5, 12 }, 1), true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 6, 7, 8, 21 }, 2), true, false, false, false),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValues", new object[] { 1, 2, 3, 6 }, 0), true, false, false, false),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValues", new object[] { 3, 4, 5, 12 }, 1), true, false, false, false),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValues", new object[] { 6, 7, 8, 21 }, 2), true, false, false, false),
                 Tuple(TESTCASE_AFTER, "ParameterizedIntValues", true, false, false, false),
                 // a test with failing test cases
                 Tuple(TESTCASE_BEFORE, "ParameterizedIntValuesFail", true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 1, 2, 3, 6 }, 0), true, false, false, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 3, 4, 5, 11 }, 1), false, false, true, false),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 6, 7, 8, 22 }, 2), false, false, true, false),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValuesFail", new object[] { 1, 2, 3, 6 }, 0), true, false, false, false),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValuesFail", new object[] { 3, 4, 5, 11 }, 1), false, false, true, false),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValuesFail", new object[] { 6, 7, 8, 22 }, 2), false, false, true, false),
                 Tuple(TESTCASE_AFTER, "ParameterizedIntValuesFail", false, false, true, false),
                 // test suite is failing
                 Tuple(TESTSUITE_AFTER, "After", false, false, true, false)
@@ -688,19 +688,19 @@ namespace GdUnit4.Tests
 
             AssertReports(events).Contains(
                 Tuple(TESTSUITE_BEFORE, "Before", new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 0, false }, 0), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedBoolValue", new object[] { 1, true }, 1), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 1, 2, 3, 6 }, 0), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 3, 4, 5, 12 }, 1), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValues", new object[] { 6, 7, 8, 21 }, 2), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 1, 2, 3, 6 }, 0), new List<TestReport>()),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 3, 4, 5, 11 }, 1), new List<TestReport>(){
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedBoolValue", new object[] { 0, false }, 0), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedBoolValue", new object[] { 1, true }, 1), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValues", new object[] { 1, 2, 3, 6 }, 0), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValues", new object[] { 3, 4, 5, 12 }, 1), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValues", new object[] { 6, 7, 8, 21 }, 2), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValuesFail", new object[] { 1, 2, 3, 6 }, 0), new List<TestReport>()),
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValuesFail", new object[] { 3, 4, 5, 11 }, 1), new List<TestReport>(){
                     new TestReport(FAILURE, 30, """
                         Expecting be equal:
                             '11' but is '12'
                         """)
                 }),
-                Tuple(TESTCASE_AFTER, TestCaseName("ParameterizedIntValuesFail", new object[] { 6, 7, 8, 22 }, 2), new List<TestReport>(){
+                Tuple(TESTCASE_AFTER, ParameterizedTestCaseName("ParameterizedIntValuesFail", new object[] { 6, 7, 8, 22 }, 2), new List<TestReport>(){
                     new TestReport(FAILURE, 30, """
                         Expecting be equal:
                             '22' but is '21'

--- a/test/src/core/GdUnitTestSuiteBuilderTest.cs
+++ b/test/src/core/GdUnitTestSuiteBuilderTest.cs
@@ -2,7 +2,9 @@ using System.IO;
 using System.Text;
 using System.Collections.Generic;
 
-namespace GdUnit4.Core.Tests
+using GdUnit4.Core;
+
+namespace GdUnit4.Tests.Core
 {
     using static Assertions;
     using static Utils;
@@ -234,8 +236,14 @@ namespace GdUnit4.Core.Tests
                     Tuple("TestBar", 42, new List<string>()),
                     Tuple("Waiting", 48, new List<string>()),
                     Tuple("TestFooBar", 54, new List<string>()),
-                    Tuple("TestCaseArguments", 62, new List<string> { "TestCaseArguments:0 [1, 2, 3, 6]", "TestCaseArguments:1 [3, 4, 5, 12]", "TestCaseArguments:2 [6, 7, 8, 21]" }),
-                    Tuple("TestCasesWithCustomTestName", 70, new List<string> { "TestCaseA", "TestCaseB", "TestCaseC" }));
+                    Tuple("TestCaseArguments", 62, new List<string> {
+                        "TestCaseArguments.TestCaseArguments(1, 2, 3, 6)",
+                        "TestCaseArguments.TestCaseArguments(3, 4, 5, 12)",
+                        "TestCaseArguments.TestCaseArguments(6, 7, 8, 21)" }),
+                    Tuple("TestCasesWithCustomTestName", 70, new List<string> {
+                        "TestCaseA.TestCaseA(1, 2, 3, 6)",
+                        "TestCaseB.TestCaseB(3, 4, 5, 12)",
+                        "TestCaseC.TestCaseC(6, 7, 8, 21)" }));
         }
     }
 }

--- a/test/src/core/SceneRunnerCSharpSceneTest.cs
+++ b/test/src/core/SceneRunnerCSharpSceneTest.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using System.Threading.Tasks;
 
-namespace GdUnit4.Tests
+namespace GdUnit4.Tests.Core
 {
     using Godot;
     using static Assertions;

--- a/test/src/core/SceneRunnerGDScriptSceneTest.cs
+++ b/test/src/core/SceneRunnerGDScriptSceneTest.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
 
-namespace GdUnit4.Tests
+namespace GdUnit4.Tests.Core
 {
     using System.IO;
     using Godot;

--- a/test/src/core/SceneRunnerInputEventIntegrationTest.cs
+++ b/test/src/core/SceneRunnerInputEventIntegrationTest.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Moq;
 
-namespace GdUnit4.Tests
+namespace GdUnit4.Tests.Core
 {
     using System.Linq;
     using Godot;

--- a/test/src/core/event/TestEventTest.cs
+++ b/test/src/core/event/TestEventTest.cs
@@ -2,7 +2,8 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace GdUnit4.Tests.Asserts;
+namespace GdUnit4.Tests.Core.Event;
+
 using static Assertions;
 
 [TestSuite]

--- a/test/src/extensions/GodotObjectExtensionsTest.cs
+++ b/test/src/extensions/GodotObjectExtensionsTest.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace GdUnit4.Tests
+namespace GdUnit4.Tests.Extensions
 {
     using static Assertions;
 

--- a/test/src/extensions/GodotVariantExtensionsTest.cs
+++ b/test/src/extensions/GodotVariantExtensionsTest.cs
@@ -1,7 +1,7 @@
 using System;
 using Godot;
 
-namespace GdUnit4.Tests
+namespace GdUnit4.Tests.Extensions
 {
     using static Assertions;
 

--- a/test/src/extractors/ValueExtractorTest.cs
+++ b/test/src/extractors/ValueExtractorTest.cs
@@ -1,4 +1,4 @@
-namespace GdUnit4.Tests
+namespace GdUnit4.Tests.Extractors
 {
     using GdUnit4.Asserts;
     using static Assertions;

--- a/testadapter/README.md
+++ b/testadapter/README.md
@@ -1,8 +1,81 @@
-# --------------------------------------------------------
-# This is the initial repository and not yet ready for use
-# --------------------------------------------------------
+
+# GdUnit4 Test Adapter
+
+This is the GdUnit4 Test Adapter, designed to facilitate the integration of GdUnit4 with test frameworks supporting the Visual Studio Test Platform.
+
+## Getting Started
 
 
+### Precondisions
+* Install the C# Dev Kit
+    Detailed instacruction can be found here https://code.visualstudio.com/docs/csharp/testing
+* Setup your test settings
+    It is important you use the right C# Dev Kit version! (Is actual a PreRelease)
+    The property is newly introduced by this issue https://github.com/microsoft/vscode-dotnettools/issues/156
 
-## What is GdUnit4 Test Adapter
-GdUnit4 Test Adapter is the VSTest Adapter to run GdUnit4 tests.
+    Open your settings.json and add this property to setup your custom test run settings.
+    ```
+        "dotnet.unitTests.runSettingsPath": "./test/.runsettings"
+    ````
+
+1. Install the GdUnit4 Test Adapter NuGet package:
+
+   ```bash
+   dotnet add package GdUnit4.TestAdapter
+   ```
+
+2. Add a reference to the GdUnit4 library in your test project:
+
+   ```bash
+   dotnet add package GdUnit4
+   ```
+
+3. Configure your test project to use GdUnit4 by adding the following to your `.csproj` file:
+
+```xml
+<Project Sdk="Godot.NET.Sdk">
+
+    <!-- ... other project settings ... -->
+
+    <ItemGroup>
+        <PackageReference Include="gdUnit4.api" Version="your-version" />
+        <ProjectReference Include="gdUnit4.test.adapter" Version="your-version"/>
+    </ItemGroup>
+
+</Project>
+```
+
+## .runsettings Configuration
+
+To configure GdUnit4 test execution, you can use a `.runsettings` file. Below is an example `.runsettings` file:
+
+```xml
+<GdUnit4>
+    <!-- Additional Godot runtime parameters -->
+    <!-- These parameters are crucial for configuring the Godot runtime to work in headless environments,
+         such as those used in automated testing or CI/CD pipelines. -->
+    <Parameters>--verbose</Parameters>
+    
+    <!-- Controls the Display name attribute of the TestCase.
+         Allowed values are SimpleName and FullyQualifiedName.
+         This likely determines how the test names are displayed in the test results. -->
+    <DisplayName>SimpleName</DisplayName>
+</GdUnit4>
+```
+
+Ensure to customize the values inside the `<Parameters>` element based on your specific requirements. This configuration is crucial for successful test execution, especially in headless environments.
+
+
+## Run tests from console
+
+`dotnet test ./test/your-project.csproj --settings ./test/.runsettings`
+
+## Contributing
+
+If you encounter issues or have suggestions for improvements, please feel free to open an issue or submit a pull request on the [GitHub repository](https://github.com/MikeSchulze/gdUnit4Mono/issues/new/choose).
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+---

--- a/testadapter/src/GdUnit4TestDiscoverer.cs
+++ b/testadapter/src/GdUnit4TestDiscoverer.cs
@@ -1,14 +1,16 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using GdUnit4.TestAdapter.Discovery;
+using GdUnit4.TestAdapter.Settings;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using static GdUnit4.TestAdapter.Discovery.CodeNavigationDataProvider;
+using static GdUnit4.TestAdapter.Settings.GdUnit4Settings;
 
 namespace GdUnit4.TestAdapter;
 
@@ -19,9 +21,9 @@ namespace GdUnit4.TestAdapter;
 public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
 {
 
-    internal static readonly TestProperty TestClassNameProperty = TestProperty.Register(
-            "GdUnit4.Test",
-            "SuiteName",
+    internal static readonly TestProperty TestMethodNameProperty = TestProperty.Register(
+            "GdUnit4.Property.TestMethodName",
+            "TestMethodName",
             typeof(string),
             TestPropertyAttributes.Hidden,
             typeof(TestCase));
@@ -32,11 +34,11 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
         IMessageLogger logger,
         ITestCaseDiscoverySink discoverySink)
     {
-        //logger.SendMessage(TestMessageLevel.Informational, $"RunSettings: {discoveryContext.RunSettings}:{discoveryContext.RunSettings?.SettingsXml}");
         var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(discoveryContext.RunSettings?.SettingsXml);
-        //logger.SendMessage(TestMessageLevel.Informational, $"RunConfiguration: {runConfiguration.TestSessionTimeout}");
-
+        var gdUnitSettingsProvider = discoveryContext.RunSettings?.GetSettings(GdUnit4Settings.RunSettingsXmlNode) as GdUnit4SettingsProvider;
+        var gdUnitSettings = gdUnitSettingsProvider?.Settings ?? new GdUnit4Settings();
         var filteredAssemblys = FilterWithoutTestAdapter(assemblyPaths);
+
         foreach (string assemblyPath in filteredAssemblys)
         {
             logger.SendMessage(TestMessageLevel.Informational, $"Discover tests for assembly: {assemblyPath}");
@@ -45,17 +47,21 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
             if (codeNavigationProvider.GetAssembly() == null) continue;
             Assembly assembly = codeNavigationProvider.GetAssembly()!;
 
+            int testsTotalDiscovered = 0;
+            int testSuiteDiscovered = 0;
             // discover GdUnit4 testsuites
             foreach (var type in assembly.GetTypes().Where(IsTestSuite))
             {
                 // discover test cases
+                var testCasesDiscovered = 0;
+                testSuiteDiscovered++;
                 var className = type.FullName!;
                 type.GetMethods()
                     .Where(m => m.IsDefined(typeof(TestCaseAttribute)))
                     .AsParallel()
                     .ForAll(mi =>
                     {
-                        var navData = codeNavigationProvider.GetNavigationData(className, mi.Name);
+                        var navData = codeNavigationProvider.GetNavigationData(className, mi);
                         if (!navData.IsValid)
                             logger.SendMessage(TestMessageLevel.Informational, $"Can't collect code navigation data for {className}:{mi.Name}    GetNavigationData -> {navData.Source}:{navData.Line}");
 
@@ -77,26 +83,42 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
                                 TestName = $"{mi.Name}",
                                 FullyQualifiedName = $"{mi.DeclaringType}.{mi.Name}"
                             })
-                            .Select(test => BuildTestCase(test.FullyQualifiedName, test.TestName, assemblyPath, navData))
+                            .Select(test => BuildTestCase(test.FullyQualifiedName, test.TestName, assemblyPath, navData, gdUnitSettings))
                             .ToList()
-                            .ForEach(discoverySink.SendTestCase);
+                            .ForEach(t =>
+                            {
+                                Interlocked.Increment(ref testsTotalDiscovered);
+                                Interlocked.Increment(ref testCasesDiscovered);
+                                discoverySink.SendTestCase(t);
+                            });
                     });
+                logger.SendMessage(TestMessageLevel.Informational, $"Discover:  TestSuite {className} with {testCasesDiscovered} TestCases found.");
             };
+
+            logger.SendMessage(TestMessageLevel.Informational, $"Discover tests done, {testSuiteDiscovered} TestSuites and total {testsTotalDiscovered} Tests found.");
         }
     }
 
-    private TestCase BuildTestCase(string fullyQualifiedName, string testName, string assemblyPath, CodeNavigation navData)
+    private TestCase BuildTestCase(string fullyQualifiedName, string testName, string assemblyPath, CodeNavigation navData, GdUnit4Settings gdUnitSettings)
     {
         TestCase testCase = new(fullyQualifiedName, new Uri(GdUnit4TestExecutor.ExecutorUri), assemblyPath)
         {
-            DisplayName = testName,
+            DisplayName = BuildDisplayName(testName, fullyQualifiedName, gdUnitSettings),
             FullyQualifiedName = fullyQualifiedName,
             CodeFilePath = navData.Source,
             LineNumber = navData.Line
         };
-        testCase.SetPropertyValue(TestClassNameProperty, testCase.DisplayName);
+        testCase.SetPropertyValue(TestMethodNameProperty, testName);
         return testCase;
     }
+
+    private static string BuildDisplayName(string testName, string fullyQualifiedName, GdUnit4Settings gdUnitSettings) =>
+        gdUnitSettings.DisplayName switch
+        {
+            DisplayNameOptions.SimpleName => testName,
+            DisplayNameOptions.FullyQualifiedName => fullyQualifiedName,
+            _ => testName
+        };
 
     private static IEnumerable<string> FilterWithoutTestAdapter(IEnumerable<string> assemblyPaths) =>
         assemblyPaths.Where(assembly => !assembly.Contains(".TestAdapter."));

--- a/testadapter/src/discovery/TestCaseDiscoverySink.cs
+++ b/testadapter/src/discovery/TestCaseDiscoverySink.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace GdUnit4.TestAdapter.Discovery;
+
+class TestCaseDiscoverySink : ITestCaseDiscoverySink
+{
+    public LinkedList<TestCase> TestCases { get; private set; } = new LinkedList<TestCase>();
+
+    public void SendTestCase(TestCase test) => TestCases.AddLast(test);
+}

--- a/testadapter/src/discovery/TestCaseDiscoverySink.cs
+++ b/testadapter/src/discovery/TestCaseDiscoverySink.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
@@ -6,7 +8,9 @@ namespace GdUnit4.TestAdapter.Discovery;
 
 class TestCaseDiscoverySink : ITestCaseDiscoverySink
 {
-    public LinkedList<TestCase> TestCases { get; private set; } = new LinkedList<TestCase>();
+    private readonly ConcurrentBag<TestCase> testCases = new();
 
-    public void SendTestCase(TestCase test) => TestCases.AddLast(test);
+    public IReadOnlyList<TestCase> TestCases => testCases.OrderBy(tc => tc.FullyQualifiedName).ToList();
+
+    public void SendTestCase(TestCase test) => testCases.Add(test);
 }

--- a/testadapter/src/execution/BaseTestExecutor.cs
+++ b/testadapter/src/execution/BaseTestExecutor.cs
@@ -20,7 +20,7 @@ internal abstract class BaseTestExecutor
         ?? throw new Exception("Godot runtime is not set! Set evn 'GODOT_BIN' is missing!");
 
     protected static EventHandler ExitHandler(IFrameworkHandle frameworkHandle) => new((sender, e)
-        => frameworkHandle.SendMessage(TestMessageLevel.Informational, "Exited: " + e.GetType()));
+        => frameworkHandle.SendMessage(TestMessageLevel.Informational, $"Exited: {e}"));
 
     protected static DataReceivedEventHandler StdErrorProcessor(IFrameworkHandle frameworkHandle) => new((sender, args) =>
     {

--- a/testadapter/src/execution/BaseTestExecutor.cs
+++ b/testadapter/src/execution/BaseTestExecutor.cs
@@ -70,10 +70,10 @@ internal abstract class BaseTestExecutor
                     break;
                 case TestEvent.TYPE.TESTCASE_BEFORE:
                     {
-                        var testCase = tests.FirstOrDefault(t => t.FullyQualifiedName.EndsWith(e.FullyQualifiedName));
+                        TestCase? testCase = FindTestCase(tests, e);
                         if (testCase == null)
                         {
-                            frameworkHandle.SendMessage(TestMessageLevel.Error, $"TESTCASE_BEFORE: cant find test case {e.FullyQualifiedName}");
+                            //frameworkHandle.SendMessage(TestMessageLevel.Error, $"TESTCASE_BEFORE: cant find test case {e.FullyQualifiedName}");
                             return;
                         }
                         frameworkHandle.RecordStart(testCase);
@@ -81,10 +81,10 @@ internal abstract class BaseTestExecutor
                     break;
                 case TestEvent.TYPE.TESTCASE_AFTER:
                     {
-                        var testCase = tests.FirstOrDefault(t => t.FullyQualifiedName.EndsWith(e.FullyQualifiedName));
+                        var testCase = FindTestCase(tests, e);
                         if (testCase == null)
                         {
-                            frameworkHandle.SendMessage(TestMessageLevel.Error, $"TESTCASE_AFTER: cant find test case {e.FullyQualifiedName}");
+                            //frameworkHandle.SendMessage(TestMessageLevel.Error, $"TESTCASE_AFTER: cant find test case {e.FullyQualifiedName}");
                             return;
                         }
                         var testResult = new TestResult(testCase)
@@ -111,6 +111,11 @@ internal abstract class BaseTestExecutor
         }
         frameworkHandle.SendMessage(TestMessageLevel.Informational, $"stdout: {json}");
     });
+
+    private static TestCase? FindTestCase(IEnumerable<TestCase> tests, TestEvent e)
+    {
+        return tests.FirstOrDefault(t => t.FullyQualifiedName.EndsWith(e.FullyQualifiedName));
+    }
 
     protected static string? LookupGodotProjectPath(string classPath)
     {

--- a/testadapter/src/execution/TestExecutor.cs
+++ b/testadapter/src/execution/TestExecutor.cs
@@ -35,6 +35,7 @@ internal class TestExecutor : BaseTestExecutor, ITestExecutor
 
     public void Run(IFrameworkHandle frameworkHandle, IRunContext runContext, IEnumerable<TestCase> testCases)
     {
+        frameworkHandle.SendMessage(TestMessageLevel.Informational, $"Start executing tests, {testCases.Count()} TestCases total.");
         // TODO split into multiple threads by using 'ParallelTestCount'
         Dictionary<string, List<TestCase>> groupedTests = testCases
             .GroupBy(t => t.CodeFilePath!)
@@ -44,6 +45,7 @@ internal class TestExecutor : BaseTestExecutor, ITestExecutor
         {
             var workingDirectory = LookupGodotProjectPath(groupedTests.First().Key);
             var configName = WriteTestRunnerConfig(groupedTests);
+            var debugArg = runContext.IsBeingDebugged ? "-d" : "";
 
             //var filteredTestCases = filterExpression != null
             //    ? testCases.FindAll(t => filterExpression.MatchTestCase(t, (propertyName) =>
@@ -52,7 +54,7 @@ internal class TestExecutor : BaseTestExecutor, ITestExecutor
             //        return t.GetPropertyValue(testProperty);
             //    }) == false)
             //    : testCases;
-            var processStartInfo = new ProcessStartInfo(@$"{GodotBin}", @$"-d --path {workingDirectory} --testadapter --configfile='{configName}' {gdUnit4Settings.Parameters}")
+            var processStartInfo = new ProcessStartInfo(@$"{GodotBin}", @$"{debugArg} --path {workingDirectory} --testadapter --configfile='{configName}' {gdUnit4Settings.Parameters}")
             {
                 StandardOutputEncoding = Encoding.Default,
                 RedirectStandardOutput = true,

--- a/testadapter/src/settings/GdUnit4Settings.cs
+++ b/testadapter/src/settings/GdUnit4Settings.cs
@@ -1,0 +1,34 @@
+
+using System.IO;
+using System.Xml;
+using System.Xml.Serialization;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace GdUnit4.TestAdapter.Settings;
+
+
+[XmlRoot(RunSettingsXmlNode)]
+public class GdUnit4Settings : TestRunSettings
+{
+
+    public const string RunSettingsXmlNode = "GdUnit4";
+
+    private static readonly XmlSerializer Serializer = new(typeof(GdUnit4Settings));
+
+    public string? Parameters { get; set; }
+
+    public GdUnit4Settings() : base(RunSettingsXmlNode)
+    {
+    }
+
+    public override XmlElement ToXml()
+    {
+        using var stringWriter = new StringWriter();
+        Serializer.Serialize(stringWriter, this);
+
+        var document = new XmlDocument();
+        document.LoadXml(stringWriter.ToString());
+
+        return document.DocumentElement!;
+    }
+}

--- a/testadapter/src/settings/GdUnit4Settings.cs
+++ b/testadapter/src/settings/GdUnit4Settings.cs
@@ -15,7 +15,16 @@ public class GdUnit4Settings : TestRunSettings
 
     private static readonly XmlSerializer Serializer = new(typeof(GdUnit4Settings));
 
+    public enum DisplayNameOptions
+    {
+        SimpleName,
+        FullyQualifiedName
+    }
+
     public string? Parameters { get; set; }
+
+
+    public DisplayNameOptions DisplayName { get; set; } = DisplayNameOptions.SimpleName;
 
     public GdUnit4Settings() : base(RunSettingsXmlNode)
     {

--- a/testadapter/src/settings/GdUnit4SettingsProvider.cs
+++ b/testadapter/src/settings/GdUnit4SettingsProvider.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Xml;
+using System.Xml.Serialization;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace GdUnit4.TestAdapter.Settings;
+
+
+[SettingsName(GdUnit4Settings.RunSettingsXmlNode)]
+public class GdUnit4SettingsProvider : ISettingsProvider
+{
+    private XmlSerializer Serializer { get; set; } = new XmlSerializer(typeof(GdUnit4Settings));
+
+    public GdUnit4Settings Settings { get; private set; } = new GdUnit4Settings();
+
+
+    public void Load(XmlReader reader)
+    {
+        try
+        {
+            if (reader?.Read() == true && reader.Name == GdUnit4Settings.RunSettingsXmlNode)
+            {
+                var settings = Serializer.Deserialize(reader) as GdUnit4Settings;
+                Settings = settings ?? new GdUnit4Settings();
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"Loading GdUnit4 Adapter settings failed! {e}");
+        }
+    }
+}


### PR DESCRIPTION
# Why
We want a test coverage, executed by the GdUnit4.test adapter

# What
- Missing RunTests implemented on the GdUnit4 test adapter
- Test run integrated into CI via test adapter
- fix run parameterized tests
- fix formating issues
- add support for custom GdUnit4 runsettings