### PR TITLE
GD-42: Fix test run stops at some point

### DIFF
--- a/api/src/core/execution/Executor.cs
+++ b/api/src/core/execution/Executor.cs
@@ -83,6 +83,9 @@ namespace GdUnit4.Executions
                     .Select(node => node.Name.ToString())
                     .ToList();
                 var task = ExecuteInternally(new TestSuite(testSuite.ResourcePath(), includedTests));
+                // use this call as workaround to hold the signal list, it is disposed for some unknown reason.
+                // could be related to https://github.com/godotengine/godot/issues/84254
+                GetSignalConnectionList("ExecutionCompleted");
                 task.GetAwaiter().OnCompleted(() => EmitSignal(SignalName.ExecutionCompleted));
             }
             // handle unexpected exceptions


### PR DESCRIPTION
# Why
The test runs stops after 7 test-suites are executed and stuck with an error at await signal ExecutionCompleted

# What
Its unclear what the root cause is, it looks like the signal connection list of the executor is cleaned for some reasons. Added just a "hack" by fetching the signal list on each test-suite run


pushed new **gdUnit4.api** version
`<PackageReference Include="gdUnit4.api" Version="4.2.0-rc.202402222030" />`