### PR TITLE
GD-62: Add full .NET8 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -484,3 +484,6 @@ dotnet_diagnostic.CA1311.severity = none
 
 # Default severity for analyzer diagnostics with category 'Usage'
 dotnet_analyzer_diagnostic.category-Usage.severity = warning
+
+# allow constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = none

--- a/PackageVersions.props
+++ b/PackageVersions.props
@@ -3,7 +3,7 @@
     <GodotVersion>4.2.1</GodotVersion>
     <GodotNetSdkVersion>$(GodotVersion)</GodotNetSdkVersion>
     <MicrosoftSdkVersion>17.9.0</MicrosoftSdkVersion>
-    <MicrosoftCodeAnalysisCSharpVersion>4.7.0</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>4.9.2</MicrosoftCodeAnalysisCSharpVersion>
     <MoqVersion>4.18.4</MoqVersion>
   </PropertyGroup>
 </Project>

--- a/api/src/asserts/StringAssert.cs
+++ b/api/src/asserts/StringAssert.cs
@@ -14,7 +14,7 @@ internal sealed class StringAssert : AssertBase<string>, IStringAssert
 
     public IStringAssert ContainsIgnoringCase(string expected)
     {
-        if (Current == null || !Current.ToLower().Contains(expected.ToLower()))
+        if (Current == null || !Current.ToLower().Contains(expected.ToLower(), System.StringComparison.OrdinalIgnoreCase))
             ThrowTestFailureReport(AssertFailures.ContainsIgnoringCase(Current, expected), Current, expected);
         return this;
     }
@@ -102,7 +102,7 @@ internal sealed class StringAssert : AssertBase<string>, IStringAssert
 
     public IStringAssert NotContainsIgnoringCase(string expected)
     {
-        if (Current != null && Current.ToLower().Contains(expected.ToLower()))
+        if (Current != null && Current.ToLower().Contains(expected.ToLower(), System.StringComparison.OrdinalIgnoreCase))
             ThrowTestFailureReport(AssertFailures.NotContainsIgnoringCase(Current, expected), Current, expected);
         return this;
     }

--- a/api/src/core/GdUnitTestSuiteBuilder.cs
+++ b/api/src/core/GdUnitTestSuiteBuilder.cs
@@ -214,7 +214,7 @@ public class GdUnitTestSuiteBuilder
                     // collect testcase if multiple TestCaseAttribute exists
                     var testCases = mi.GetCustomAttributes(typeof(TestCaseAttribute))
                         .Cast<TestCaseAttribute>()
-                        .Where(attr => attr != null && (attr.Arguments?.Any() ?? false))
+                        .Where(attr => attr != null && attr.Arguments?.Length != 0)
                         .Select(attr => TestCase.BuildTestCaseName(attr.TestName ?? mi.Name, attr))
                         .ToList();
                     // create test

--- a/api/src/core/SceneRunner.cs
+++ b/api/src/core/SceneRunner.cs
@@ -110,7 +110,7 @@ internal sealed class SceneRunner : ISceneRunner
     /// </summary>
     /// <param name="inputEvent"></param>
     /// <returns></returns>
-    private ISceneRunner HandleInputEvent(InputEvent inputEvent)
+    private SceneRunner HandleInputEvent(InputEvent inputEvent)
     {
         if (inputEvent is InputEventMouse ie)
             Input.WarpMouse(ie.Position);

--- a/api/src/core/execution/AfterExecutionStage.cs
+++ b/api/src/core/execution/AfterExecutionStage.cs
@@ -24,13 +24,13 @@ internal class AfterExecutionStage : ExecutionStage<AfterAttribute>
         context.FireAfterEvent();
     }
 
-    private static TestStageAttribute? AfterAttribute(ExecutionContext context) => context.TestSuite.Instance
+    private static AfterAttribute? AfterAttribute(ExecutionContext context) => context.TestSuite.Instance
         .GetType()
         .GetMethods()
         .FirstOrDefault(m => m.IsDefined(typeof(AfterAttribute)))
         ?.GetCustomAttribute<AfterAttribute>();
 
-    private static TestStageAttribute? BeforeAttribute(ExecutionContext context) => context.TestSuite.Instance
+    private static BeforeAttribute? BeforeAttribute(ExecutionContext context) => context.TestSuite.Instance
         .GetType()
         .GetMethods()
         .FirstOrDefault(m => m.IsDefined(typeof(BeforeAttribute)))

--- a/api/src/core/execution/AfterTestExecutionStage.cs
+++ b/api/src/core/execution/AfterTestExecutionStage.cs
@@ -26,13 +26,13 @@ internal class AfterTestExecutionStage : ExecutionStage<AfterTestAttribute>
         context.FireAfterTestEvent();
     }
 
-    private static TestStageAttribute? AfterTestAttribute(ExecutionContext context) => context.TestSuite.Instance
+    private static AfterTestAttribute? AfterTestAttribute(ExecutionContext context) => context.TestSuite.Instance
         .GetType()
         .GetMethods()
         .FirstOrDefault(m => m.IsDefined(typeof(AfterTestAttribute)))
         ?.GetCustomAttribute<AfterTestAttribute>();
 
-    private static TestStageAttribute? BeforeTestAttribute(ExecutionContext context) => context.TestSuite.Instance
+    private static BeforeTestAttribute? BeforeTestAttribute(ExecutionContext context) => context.TestSuite.Instance
         .GetType()
         .GetMethods()
         .FirstOrDefault(m => m.IsDefined(typeof(BeforeTestAttribute)))

--- a/api/src/core/execution/Executor.cs
+++ b/api/src/core/execution/Executor.cs
@@ -132,7 +132,7 @@ public sealed partial class Executor : Godot.RefCounted, IExecutor
         // handle unexpected exceptions
         catch (Exception e)
         {
-            Console.Error.WriteLine("Unexpected Exception: %s \nStackTrace: %s", e.Message, e.StackTrace);
+            Console.Error.WriteLine($"Unexpected Exception: {e.Message} \nStackTrace: {e.StackTrace}");
         }
         finally
         {

--- a/api/src/core/execution/TestCase.cs
+++ b/api/src/core/execution/TestCase.cs
@@ -45,7 +45,7 @@ internal sealed class TestCase
         return new object[] { input };
     }
 
-    private IEnumerable<object> InitialParameters()
+    private List<object> InitialParameters()
         => MethodInfo.GetParameters()
             .SelectMany(pi => pi.GetCustomAttributesData()
                 .Where(attr => attr.AttributeType == typeof(FuzzerAttribute))
@@ -55,13 +55,13 @@ internal sealed class TestCase
                     return attr.Constructor.Invoke(arguments);
                 }
             )
-         ).ToArray();
+         ).ToList();
 
     public object[] Arguments => Parameters.SelectMany(ResolveParam).ToArray();
 
     public static string BuildTestCaseName(string testName, TestCaseAttribute attribute)
     {
-        if (attribute.Arguments.Any())
+        if (attribute.Arguments.Length > 0)
         {
             var saveCulture = Thread.CurrentThread.CurrentCulture;
             Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US", true);

--- a/api/src/core/execution/TestFailedException.cs
+++ b/api/src/core/execution/TestFailedException.cs
@@ -24,8 +24,4 @@ public class TestFailedException : Exception
         }
         return -1;
     }
-
-    protected TestFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
-    {
-    }
 }

--- a/api/src/core/execution/TestSuite.cs
+++ b/api/src/core/execution/TestSuite.cs
@@ -44,7 +44,7 @@ internal sealed class TestSuite : IDisposable
         testCases = new Lazy<IEnumerable<TestCase>>(() => LoadTestCases(type, syntaxTree, includedTests, primitiveFilter));
     }
 
-    private IEnumerable<TestCase> LoadTestCases(Type type, CompilationUnitSyntax? syntaxTree, IEnumerable<string>? includedTests = null, bool primitiveFilter = false)
+    private List<TestCase> LoadTestCases(Type type, CompilationUnitSyntax? syntaxTree, IEnumerable<string>? includedTests = null, bool primitiveFilter = false)
         => type.GetMethods()
             .Where(m => m.IsDefined(typeof(TestCaseAttribute)))
             .Where(FilterByTestCaseName(includedTests, primitiveFilter))
@@ -69,7 +69,7 @@ internal sealed class TestSuite : IDisposable
             Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US", true);
             var testCases = mi.GetCustomAttributes(typeof(TestCaseAttribute))
                 .Cast<TestCaseAttribute>()
-                .Where(attr => attr != null && (attr.Arguments?.Any() ?? false))
+                .Where(attr => attr != null && attr.Arguments?.Length != 0)
                 .Select(attr => primitiveFilter ? mi.Name : $"{attr.TestName ?? mi.Name}({attr.Arguments.Formatted()})")
                 .DefaultIfEmpty($"{mi.Name}")
                 .ToList();

--- a/api/src/core/execution/TestSuiteExecutionStage.cs
+++ b/api/src/core/execution/TestSuiteExecutionStage.cs
@@ -13,16 +13,16 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
         AfterTestStage = new AfterTestExecutionStage(testSuite);
     }
 
-    private IExecutionStage BeforeStage
+    private BeforeExecutionStage BeforeStage
     { get; set; }
 
-    private IExecutionStage AfterStage
+    private AfterExecutionStage AfterStage
     { get; set; }
 
-    private IExecutionStage BeforeTestStage
+    private BeforeTestExecutionStage BeforeTestStage
     { get; set; }
 
-    private IExecutionStage AfterTestStage
+    private AfterTestExecutionStage AfterTestStage
     { get; set; }
 
     public async Task Execute(ExecutionContext testSuiteContext)

--- a/api/src/core/exensions/GdUnitExtensions.cs
+++ b/api/src/core/exensions/GdUnitExtensions.cs
@@ -35,7 +35,7 @@ public static partial class GdUnitExtensions
     public static string Formatted(this object? value) => value.Format();
     public static string Formatted(this string? value) => $"\"{value?.ToString()}\"" ?? "<Null>";
     public static string Formatted(this Godot.Variant[] args, int indentation = 0) => string.Join(", ", args.Cast<Godot.Variant>().Select(v => v.Formatted())).Indentation(indentation);
-    public static string Formatted(this Godot.Collections.Array args, int indentation = 0) => args.Cast<IEnumerable>().Formatted(indentation);
+    public static string Formatted(this Godot.Collections.Array args, int indentation = 0) => args.UnboxVariant()?.Formatted(indentation) ?? "<empty>";
     public static string Formatted(this object?[] args, int indentation = 0) => string.Join(", ", args.ToArray().Select(Formatted)).Indentation(indentation);
     public static string Formatted(this IEnumerable args, int indentation = 0) => string.Join(", ", args.Cast<object>().Select(Formatted)).Indentation(indentation);
     public static string UnixFormat(this string value) => value.Replace("\r", string.Empty);

--- a/api/src/core/exensions/GodotVariantExtensions.cs
+++ b/api/src/core/exensions/GodotVariantExtensions.cs
@@ -25,7 +25,7 @@ public static class GodotVariantExtensions
         return value;
     }
 
-    private static IDictionary<object, object?> UnboxVariant(this Godot.Collections.Dictionary dict)
+    private static Dictionary<object, object?> UnboxVariant(this Godot.Collections.Dictionary dict)
     {
         var unboxed = new Dictionary<object, object?>();
         foreach (var kvp in dict)
@@ -33,7 +33,7 @@ public static class GodotVariantExtensions
         return unboxed;
     }
 
-    private static ICollection<object?> UnboxVariant(this Godot.Collections.Array values)
+    private static List<object?> UnboxVariant(this Godot.Collections.Array values)
     {
         var unboxed = new List<object?>();
         foreach (var value in values)
@@ -41,7 +41,7 @@ public static class GodotVariantExtensions
         return unboxed;
     }
 
-    private static ICollection<object?> UnboxVariant(this Variant[] values)
+    private static List<object?> UnboxVariant(this Variant[] values)
     {
         var unboxed = new List<object?>();
         foreach (var value in values)

--- a/example/exampleProject.csproj
+++ b/example/exampleProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Godot.NET.Sdk/4.2.1">
   <Import Project="../PackageVersions.props" />
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <LangVersion>11.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
-    "sdk": {
-        "version": "7.0.0",
-        "rollForward": "latestMajor"
-    },
-    "msbuild-sdks": {
-        "Godot.NET.Sdk": "4.2.1"
-    }
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMajor"
+  },
+  "msbuild-sdks": {
+    "Godot.NET.Sdk": "4.2.1"
+  }
 }

--- a/test/.runsettings
+++ b/test/.runsettings
@@ -2,8 +2,9 @@
 <RunSettings>
     <RunConfiguration>
         <MaxCpuCount>1</MaxCpuCount>
+        <TestAdaptersPaths>.</TestAdaptersPaths>
         <ResultsDirectory>./TestResults</ResultsDirectory>
-        <TargetFrameworkVersion>net7.0</TargetFrameworkVersion>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <TestSessionTimeout>180000</TestSessionTimeout>
         <TreatNoTestsAsError>true</TreatNoTestsAsError>
     </RunConfiguration>

--- a/test/gdUnit4Test.csproj
+++ b/test/gdUnit4Test.csproj
@@ -5,7 +5,7 @@
         <Copyright>© 2024 Mike Schulze</Copyright>
         <Authors>Mike Schulze</Authors>
 
-        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <LangVersion>11.0</LangVersion>
         <Nullable>enable</Nullable>
         <NullableReferenceTypes>true</NullableReferenceTypes>

--- a/testadapter/src/GdUnit4TestDiscoverer.cs
+++ b/testadapter/src/GdUnit4TestDiscoverer.cs
@@ -73,7 +73,7 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
                         // Collect parameterized tests or build a single test
                         mi.GetCustomAttributes(typeof(TestCaseAttribute))
                             .Cast<TestCaseAttribute>()
-                            .Where(attr => attr != null && (attr.Arguments?.Any() ?? false))
+                            .Where(attr => attr != null && attr.Arguments?.Length != 0)
                             .Select(attr =>
                             {
                                 var saveCulture = Thread.CurrentThread.CurrentCulture;

--- a/testadapter/src/GdUnit4TestExecutor.cs
+++ b/testadapter/src/GdUnit4TestExecutor.cs
@@ -12,14 +12,14 @@ using GdUnit4.TestAdapter.Discovery;
 using GdUnit4.TestAdapter.Settings;
 
 [ExtensionUri(ExecutorUri)]
-public class GdUnit4TestExecutor : ITestExecutor
+public class GdUnit4TestExecutor : ITestExecutor, IDisposable
 {
     ///<summary>
     /// The Uri used to identify the GdUnit4 Executor
     ///</summary>
     public const string ExecutorUri = "executor://GdUnit4.TestAdapter";
 
-    private Execution.ITestExecutor? executor;
+    private Execution.TestExecutor? executor;
 
     private IFrameworkHandle? frameworkHandle;
 
@@ -88,4 +88,9 @@ public class GdUnit4TestExecutor : ITestExecutor
         executor?.Cancel();
     }
 
+    public void Dispose()
+    {
+        executor?.Dispose();
+        GC.SuppressFinalize(this);
+    }
 }

--- a/testadapter/src/execution/ITestExecutor.cs
+++ b/testadapter/src/execution/ITestExecutor.cs
@@ -1,12 +1,13 @@
 namespace GdUnit4.TestAdapter.Execution;
 
+using System;
 using System.Collections.Generic;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 
-internal interface ITestExecutor
+internal interface ITestExecutor : IDisposable
 {
 
     public const int DEFAULT_SESSION_TIMEOUT = 30000;

--- a/testadapter/src/execution/TestExecutor.cs
+++ b/testadapter/src/execution/TestExecutor.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 using GdUnit4.TestAdapter.Settings;
 
-internal sealed class TestExecutor : BaseTestExecutor, ITestExecutor, IDisposable
+internal sealed class TestExecutor : BaseTestExecutor, ITestExecutor
 {
     private const string TempTestRunnerDir = "gdunit4_testadapter";
 
@@ -47,7 +47,7 @@ internal sealed class TestExecutor : BaseTestExecutor, ITestExecutor, IDisposabl
             .ToDictionary(group => group.Key, group => group.ToList());
 
         var workingDirectory = LookupGodotProjectPath(groupedTests.First().Key);
-        _ = workingDirectory ?? throw new ArgumentNullException(nameof(workingDirectory), "Cannot determine the godot.project!");
+        _ = workingDirectory ?? throw new InvalidOperationException($"Cannot determine the godot.project! The workingDirectory is not set");
         InstallTestRunnerAndBuild(frameworkHandle, workingDirectory);
 
         frameworkHandle.SendMessage(TestMessageLevel.Informational, @$"Run tests -------->");


### PR DESCRIPTION
# Why
We want to support the latest .NET version

# What
- switch to SDK 8.0.0
- update runsettings to support .NET7 and .NET8
- use for test and example project .NET8