### PR TITLE
GD-22: Calling Invoke on `SceneRunner` must propagate exceptions

### DIFF
--- a/api/src/IExceptionAssert.cs
+++ b/api/src/IExceptionAssert.cs
@@ -14,6 +14,18 @@ public interface IExceptionAssert : IAssert
     IExceptionAssert IsInstanceOf<TExpectedType>();
 
 
+    /// <summary>
+    /// Verifies the exception is thrown at expected file line number.
+    /// </summary>
+    /// <param name="lineNumber"></param>
+    IExceptionAssert HasFileLineNumber(int lineNumber);
+
+    /// <summary>
+    /// Verifies the exception is thrown at expected file name.
+    /// </summary>
+    /// <param name="fileName"></param>
+    IExceptionAssert HasFileName(string fileName);
+
     /// <summary> Verifies that the exception has the expected property value.</summary>
     IExceptionAssert HasPropertyValue(string propertyName, object expected);
 }

--- a/api/src/ISceneRunner.cs
+++ b/api/src/ISceneRunner.cs
@@ -228,6 +228,15 @@ public interface ISceneRunner : IDisposable
     public Variant Invoke(string name, params Variant[] args);
 
     /// <summary>
+    /// Invokes an async method by given name and arguments.
+    /// </summary>
+    /// <param name="name">The name of method to invoke</param>
+    /// <param name="args">The function arguments</param>
+    /// <returns>The return value of invoked method</returns>
+    /// <exception cref="MissingMethodException"/>
+    public Task<Variant> InvokeAsync(string name, params Variant[] args);
+
+    /// <summary>
     /// Returns the value of the property with the specified name.
     /// </summary>
     /// <param name="name">The name of the property.</param>

--- a/api/src/core/SceneRunner.cs
+++ b/api/src/core/SceneRunner.cs
@@ -350,11 +350,17 @@ internal sealed class SceneRunner : ISceneRunner
 
     public async Task AwaitIdleFrame() => await ISceneRunner.SyncProcessFrame;
 
+
     public Variant Invoke(string name, params Variant[] args)
+        => GodotObjectExtensions.Invoke(CurrentScene, name, args)
+            .GetAwaiter()
+            .GetResult()
+            .ToVariant();
+
+    public async Task<Variant> InvokeAsync(string name, params Variant[] args)
     {
-        if (!CurrentScene.HasMethod(name))
-            throw new MissingMethodException($"The method '{name}' not exist on loaded scene.");
-        return CurrentScene.Call(name, args);
+        var result = await GodotObjectExtensions.Invoke(CurrentScene, name, args);
+        return result.ToVariant();
     }
 
     public dynamic? GetProperty(string name)

--- a/api/src/core/exensions/GodotVariantExtensions.cs
+++ b/api/src/core/exensions/GodotVariantExtensions.cs
@@ -75,6 +75,8 @@ public static class GodotVariantExtensions
 
     private static Variant ToVariantByType(object obj)
     {
+        if (obj is Variant v)
+            return v;
         if (obj is System.Collections.IList list)
             return list.ToGodotArray();
 
@@ -88,8 +90,8 @@ public static class GodotVariantExtensions
     {
         Variant.Type.Nil => null,
         Variant.Type.Bool => v.AsBool(),
-        Variant.Type.Int => v.AsInt64(),
-        Variant.Type.Float => v.AsDouble(),
+        Variant.Type.Int => v.AsInt32(),
+        Variant.Type.Float => v.AsSingle(),
         Variant.Type.String => v.AsString(),
         Variant.Type.Vector2 => v.AsVector2(),
         Variant.Type.Vector2I => v.AsVector2I(),

--- a/clean.sh
+++ b/clean.sh
@@ -4,6 +4,8 @@ rm -rf ./api/nupkg/net7.0/
 rm -rf ./api/nupkg/*.nupkg
 rm -rf ./api/obj
 
+rm -rf .godot
+
 rm -rf ./test/.godot
 rm -rf ./test/gdunit4_testadapter
 

--- a/test/project.godot
+++ b/test/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="gdUnit4Test"
-config/features=PackedStringArray("4.2.1", "C#", "Forward Plus")
+config/features=PackedStringArray("4.2", "4.2.1", "C#", "Forward Plus")
 config/icon="res://icon.svg"
 
 [dotnet]

--- a/test/src/asserts/AssertionsTest.cs
+++ b/test/src/asserts/AssertionsTest.cs
@@ -20,11 +20,11 @@ public class AssertionsTest
     public void AssertThatVariants()
     {
         // Godot number Variants
-        AssertObject(AssertThat(Variant.From((sbyte)-1))).IsInstanceOf<INumberAssert<long>>();
-        AssertObject(AssertThat(Variant.From(11))).IsInstanceOf<INumberAssert<long>>();
-        AssertObject(AssertThat(Variant.From(12L))).IsInstanceOf<INumberAssert<long>>();
-        AssertObject(AssertThat(Variant.From(1.4f))).IsInstanceOf<INumberAssert<double>>();
-        AssertObject(AssertThat(Variant.From(1.5d))).IsInstanceOf<INumberAssert<double>>();
+        AssertObject(AssertThat(Variant.From((sbyte)-1))).IsInstanceOf<INumberAssert<int>>();
+        AssertObject(AssertThat(Variant.From(11))).IsInstanceOf<INumberAssert<int>>();
+        AssertObject(AssertThat(Variant.From(12L))).IsInstanceOf<INumberAssert<int>>();
+        AssertObject(AssertThat(Variant.From(1.4f))).IsInstanceOf<INumberAssert<float>>();
+        AssertObject(AssertThat(Variant.From(1.5d))).IsInstanceOf<INumberAssert<float>>();
     }
 
     [TestCase]

--- a/test/src/core/SceneRunnerCSharpSceneTest.cs
+++ b/test/src/core/SceneRunnerCSharpSceneTest.cs
@@ -65,7 +65,7 @@ public sealed class SceneRunnerCSharpSceneTest
         AssertString(sceneRunner.Invoke("Add", 10, 12).ToString()).IsEqual("22");
         AssertThrown(() => sceneRunner.Invoke("Sub", 12, 10))
             .IsInstanceOf<System.MissingMethodException>()
-            .HasMessage("The method 'Sub' not exist on loaded scene.");
+            .HasMessage("The method 'Sub' not exist on this instance.");
     }
 
     [TestCase(Timeout = 1200)]

--- a/test/src/core/SceneRunnerGDScriptSceneTest.cs
+++ b/test/src/core/SceneRunnerGDScriptSceneTest.cs
@@ -66,7 +66,7 @@ public class SceneRunnerGDScriptSceneTest
         AssertString(sceneRunner.Invoke("add", 10, 12).ToString()).IsEqual("22");
         AssertThrown(() => sceneRunner.Invoke("sub", 12, 10))
             .IsInstanceOf<System.MissingMethodException>()
-            .HasMessage("The method 'sub' not exist on loaded scene.");
+            .HasMessage("The method 'sub' not exist on this instance.");
     }
 
     [TestCase(Timeout = 1200)]

--- a/test/src/core/TestSuiteFailWithExceptions.cs
+++ b/test/src/core/TestSuiteFailWithExceptions.cs
@@ -1,0 +1,22 @@
+namespace GdUnit4.Tests.Core;
+
+using System;
+
+using static Assertions;
+
+[TestSuite]
+public class TestSuiteFailWithExceptions
+{
+
+    [TestCase]
+    public void ExceptionIsThrownOnSceneInvoke()
+    {
+        var runner = ISceneRunner.Load("res://src/core/resources/scenes/TestSceneWithExceptionTest.tscn");
+
+        AssertThrown(() => runner.Invoke("SomeMethodThatThrowsException"))
+            .IsInstanceOf<InvalidOperationException>()
+            .HasFileLineNumber(12)
+            .HasFileName("src/core/resources/scenes/TestSceneWithExceptionTest.cs")
+            .HasMessage("Test Exception");
+    }
+}

--- a/test/src/core/resources/scenes/TestSceneWithExceptionTest.cs
+++ b/test/src/core/resources/scenes/TestSceneWithExceptionTest.cs
@@ -1,0 +1,14 @@
+namespace GdUnit4.Tests.Resources;
+
+using System;
+
+using Godot;
+
+public partial class TestSceneWithExceptionTest : Control
+{
+    public void SomeMethodThatThrowsException()
+    {
+        Console.WriteLine("Throw a test exception");
+        throw new InvalidOperationException("Test Exception");
+    }
+}

--- a/test/src/core/resources/scenes/TestSceneWithExceptionTest.tscn
+++ b/test/src/core/resources/scenes/TestSceneWithExceptionTest.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3 uid="uid://cjd3v7it80k0u"]
+
+[ext_resource type="Script" path="res://src/core/resources/scenes/TestSceneWithExceptionTest.cs" id="1_m8etn"]
+
+[node name="TestSceneWithExceptionTest" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_m8etn")


### PR DESCRIPTION
# Why
When using `Invoke` on the `SceneRunner`, no exceptions are forwarded because Godot `call` does not transfer the exceptions to C# scripts.

# What
- Refactor the `Invoke` extension do handle it explicitly for `GDScripts` and `CSharpScripts`.
- Fix handle calling static methods when invoke
- `SceneRunner::Invoke` forward to  `Invoke` extension implementation
- Added new `InvokeAsync` to the `SceneRunner` to support async calls
- Fix invalid Variant unboxing of integer and float
- Improved the `ExceptionAssert` by providing new methods to verify for exception file line number and file name