### PR TITLE
GD-49: Revision of the stack trace collection for failed tests

### DIFF
--- a/api/src/IExceptionAssert.cs
+++ b/api/src/IExceptionAssert.cs
@@ -9,10 +9,8 @@ public interface IExceptionAssert : IAssert
     /// <summary> Verifies that the exception message starts with the given value.</summary>
     IExceptionAssert StartsWithMessage(string value);
 
-
     /// <summary> Verifies that the exception message starts with the given value.</summary>
     IExceptionAssert IsInstanceOf<TExpectedType>();
-
 
     /// <summary>
     /// Verifies the exception is thrown at expected file line number.
@@ -21,7 +19,7 @@ public interface IExceptionAssert : IAssert
     IExceptionAssert HasFileLineNumber(int lineNumber);
 
     /// <summary>
-    /// Verifies the exception is thrown at expected file name.
+    /// Verifies the exception is thrown in expected file name.
     /// </summary>
     /// <param name="fileName"></param>
     IExceptionAssert HasFileName(string fileName);

--- a/api/src/asserts/AssertBase.cs
+++ b/api/src/asserts/AssertBase.cs
@@ -47,12 +47,13 @@ internal abstract class AssertBase<TValue> : IAssertBase<TValue>
         return this;
     }
 
-#pragma warning disable IDE0060
-    protected void ThrowTestFailureReport(string message, object? current, object? expected, int stackFrameOffset = 0, int lineNumber = -1)
+
+#pragma warning disable IDE0060 // Remove unused parameter
+    protected void ThrowTestFailureReport(string message, object? current, object? expected)
+#pragma warning restore IDE0060 // Remove unused parameter
     {
-#pragma warning restore
         var failureMessage = (CustomFailureMessage ?? message).UnixFormat();
         CurrentFailureMessage = failureMessage;
-        throw new TestFailedException(failureMessage, lineNumber);
+        throw new TestFailedException(failureMessage);
     }
 }

--- a/api/src/asserts/ExceptionAssert.cs
+++ b/api/src/asserts/ExceptionAssert.cs
@@ -43,8 +43,16 @@ internal sealed class ExceptionAssert<T> : IExceptionAssert
 
     public IExceptionAssert HasFileLineNumber(int lineNumber)
     {
-        var stackFrame = new StackTrace(Current!, true).GetFrame(0);
-        var currentLine = stackFrame?.GetFileLineNumber();
+        int currentLine;
+        if (Current is TestFailedException e)
+        {
+            currentLine = e.LineNumber;
+        }
+        else
+        {
+            var stackFrame = new StackTrace(Current!, true).GetFrame(0);
+            currentLine = stackFrame?.GetFileLineNumber() ?? -1;
+        }
         if (currentLine != lineNumber)
             ThrowTestFailureReport(AssertFailures.IsEqual(currentLine, lineNumber));
         return this;
@@ -52,9 +60,17 @@ internal sealed class ExceptionAssert<T> : IExceptionAssert
 
     public IExceptionAssert HasFileName(string fileName)
     {
-        var stackFrame = new StackTrace(Current!, true).GetFrame(0);
-        var currentFileName = stackFrame?.GetFileName() ?? "";
         var fullPath = Path.GetFullPath(fileName);
+        string? currentFileName;
+        if (Current is TestFailedException e)
+        {
+            currentFileName = e.FileName ?? "";
+        }
+        else
+        {
+            var stackFrame = new StackTrace(Current!, true).GetFrame(0);
+            currentFileName = stackFrame?.GetFileName() ?? "";
+        }
         if (!currentFileName.Equals(fullPath, StringComparison.Ordinal))
             ThrowTestFailureReport(AssertFailures.IsEqual(currentFileName ?? "", fullPath));
         return this;
@@ -87,5 +103,12 @@ internal sealed class ExceptionAssert<T> : IExceptionAssert
     {
         var failureMessage = CustomFailureMessage ?? message;
         throw new TestFailedException(failureMessage);
+    }
+
+    internal string? GetExceptionStackTrace()
+    {
+        if (Current is TestFailedException tfe)
+            return tfe.StackTrace;
+        return Current?.StackTrace ?? null;
     }
 }

--- a/api/src/asserts/ObjectAssert.cs
+++ b/api/src/asserts/ObjectAssert.cs
@@ -5,7 +5,7 @@ internal sealed class ObjectAssert : AssertBase<object>, IObjectAssert
     {
         var type = current?.GetType();
         if (type != null && type.IsPrimitive)
-            ThrowTestFailureReport($"ObjectAssert initial error: current is primitive <{type}>", Current, null, 1);
+            ThrowTestFailureReport($"ObjectAssert initial error: current is primitive <{type}>", Current, null);
     }
 
     public IObjectAssert IsNotInstanceOf<TExpectedType>()

--- a/api/src/core/execution/ExecutionStage.cs
+++ b/api/src/core/execution/ExecutionStage.cs
@@ -82,7 +82,7 @@ internal abstract class ExecutionStage<T> : IExecutionStage
     private static void ReportAsFailure(ExecutionContext context, TestFailedException e)
     {
         if (context.FailureReporting)
-            context.ReportCollector.Consume(new TestReport(TestReport.ReportType.FAILURE, e.LineNumber, e.Message));
+            context.ReportCollector.Consume(new TestReport(e));
     }
 
     private static void ReportUnexpectedException(ExecutionContext context, Exception exception)

--- a/api/src/core/execution/TestFailedException.cs
+++ b/api/src/core/execution/TestFailedException.cs
@@ -2,15 +2,50 @@ namespace GdUnit4.Exceptions;
 
 using System;
 using System.Diagnostics;
+using System.Reflection;
 
 [Serializable]
 public class TestFailedException : Exception
 {
     public int LineNumber
+    { get; private set; } = -1;
+
+    public string? FileName
     { get; private set; }
 
+    public new string? StackTrace { get; private set; }
+
     public TestFailedException(string message, int lineNumber = -1) : base(message)
-        => LineNumber = lineNumber == -1 ? GetRootCauseLineNumber() : lineNumber;
+    {
+        LineNumber = lineNumber == -1 ? GetRootCauseLineNumber() : lineNumber;
+        var frame = new StackFrame(1, true);
+        var st = new StackTrace(frame);
+        StackTrace = st.ToString();
+    }
+
+    public TestFailedException(string message) : base(message)
+    {
+        foreach (var frame in new StackTrace(true).GetFrames())
+        {
+            var mb = frame.GetMethod();
+            // we only collect test-suite related stack frames
+
+            // skip gdunit4 api frames and skip system api frames do only collect test relates frames
+            if (mb is MethodInfo mi
+                && mi.Module.Assembly != typeof(TestFailedException).Assembly)
+            {
+                if (frame.GetFileLineNumber() > 0)
+                {
+                    LineNumber = LineNumber == -1 ? frame.GetFileLineNumber() : LineNumber;
+                    FileName ??= frame.GetFileName();
+                    StackTrace += new StackTrace(frame).ToString();
+                }
+                // end collect frames at test case attribute
+                if (mi.IsDefined(typeof(TestCaseAttribute)))
+                    break;
+            }
+        }
+    }
 
     private static int GetRootCauseLineNumber()
     {

--- a/api/src/core/report/TestReport.cs
+++ b/api/src/core/report/TestReport.cs
@@ -4,6 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using GdUnit4.Exceptions;
+
+using Newtonsoft.Json;
 
 public sealed class TestReport : IEquatable<TestReport>
 {
@@ -19,18 +22,30 @@ public sealed class TestReport : IEquatable<TestReport>
         ABORT
     }
 
-    public TestReport(ReportType type, int lineNumber, string message)
+    [JsonConstructor]
+    public TestReport(ReportType type, int lineNumber, string message, string? stackTrace = null)
     {
         Type = type;
         LineNumber = lineNumber;
         Message = message.UnixFormat();
+        StackTrace = stackTrace;
+    }
+
+    public TestReport(TestFailedException e)
+    {
+        Type = ReportType.FAILURE;
+        LineNumber = e.LineNumber;
+        Message = e.Message;
+        StackTrace = e.StackTrace;
     }
 
     public ReportType Type { get; private set; }
 
-    public int LineNumber { get; set; }
+    public int LineNumber { get; set; } = -1;
 
     public string Message { get; private set; }
+
+    public string? StackTrace { get; set; }
 
     private static IEnumerable<ReportType> ErrorTypes => new[] { ReportType.TERMINATED, ReportType.INTERRUPTED, ReportType.ABORT };
 

--- a/test/src/asserts/AssertionsTest.cs
+++ b/test/src/asserts/AssertionsTest.cs
@@ -13,7 +13,7 @@ public class AssertionsTest
     [TestCase]
     public void DoAssertNotYetImplemented()
         => AssertThrown(() => AssertNotYetImplemented())
-            .HasPropertyValue("LineNumber", 15)
+            .HasFileLineNumber(15)
             .HasMessage("Test not yet implemented!");
 
     [TestCase]

--- a/test/src/asserts/BoolAssertTest.cs
+++ b/test/src/asserts/BoolAssertTest.cs
@@ -13,7 +13,7 @@ public class BoolAssertTest
         AssertBool(true).IsTrue();
         AssertThrown(() => AssertBool(false).IsTrue())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 14)
+            .HasFileLineNumber(14)
             .HasMessage("Expecting: 'True' but is 'False'");
     }
 
@@ -23,7 +23,7 @@ public class BoolAssertTest
         AssertBool(false).IsFalse();
         AssertThrown(() => AssertBool(true).IsFalse())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 24)
+            .HasFileLineNumber(24)
             .HasMessage("Expecting: 'False' but is 'True'");
     }
 
@@ -32,7 +32,7 @@ public class BoolAssertTest
     {
         AssertThrown(() => AssertBool(true).IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 33)
+            .HasFileLineNumber(33)
             .StartsWithMessage("""
                 Expecting be <Null>:
                  but is
@@ -40,7 +40,7 @@ public class BoolAssertTest
                 """);
         AssertThrown(() => AssertBool(false).IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 41)
+            .HasFileLineNumber(41)
             .StartsWithMessage("""
                 Expecting be <Null>:
                  but is
@@ -62,7 +62,7 @@ public class BoolAssertTest
         AssertBool(false).IsEqual(false);
         AssertThrown(() => AssertBool(true).IsEqual(false))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 63)
+            .HasFileLineNumber(63)
             .HasMessage("""
                 Expecting be equal:
                     'False' but is 'True'
@@ -76,7 +76,7 @@ public class BoolAssertTest
         AssertBool(false).IsNotEqual(true);
         AssertThrown(() => AssertBool(true).IsNotEqual(true))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 77)
+            .HasFileLineNumber(77)
             .HasMessage("""
                 Expecting be NOT equal:
                     'True' but is 'True'
@@ -94,7 +94,7 @@ public class BoolAssertTest
     public void OverrideFailureMessage()
         => AssertThrown(() => AssertBool(true).OverrideFailureMessage("Custom failure message").IsFalse())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 95)
+            .HasFileLineNumber(95)
             .HasMessage("Custom failure message");
 
     [TestCase]

--- a/test/src/asserts/DictionaryAssertTest.cs
+++ b/test/src/asserts/DictionaryAssertTest.cs
@@ -31,7 +31,7 @@ public class DictionaryAssertTest
                 .OverrideFailureMessage("Custom failure message")
                 .IsNotNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 30)
+            .HasFileLineNumber(30)
             .HasMessage("Custom failure message");
 
     [TestCase]
@@ -54,7 +54,7 @@ public class DictionaryAssertTest
         current.Add("a3", 300);
         AssertThrown(() => AssertThat(current).IsEqual(expected))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 55)
+            .HasFileLineNumber(55)
             .HasMessage("""
                 Expecting be equal:
                     {"a1", "100"}; {"a2", "200"}

--- a/test/src/asserts/EnumerableAssertTest.cs
+++ b/test/src/asserts/EnumerableAssertTest.cs
@@ -19,7 +19,7 @@ public partial class EnumerableAssertTest
         // should fail because the current is not null
         AssertThrown(() => AssertArray(Array.Empty<object>()).IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 20)
+            .HasFileLineNumber(20)
             .HasMessage("""
                     Expecting be <Null>:
                      but is
@@ -27,7 +27,7 @@ public partial class EnumerableAssertTest
                     """);
         AssertThrown(() => AssertArray(Array.Empty<int>()).IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 28)
+            .HasFileLineNumber(28)
             .HasMessage("""
                     Expecting be <Null>:
                      but is
@@ -36,7 +36,7 @@ public partial class EnumerableAssertTest
         // with godot array
         AssertThrown(() => AssertArray(new Godot.Collections.Array()).IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 37)
+            .HasFileLineNumber(37)
             .HasMessage("""
                     Expecting be <Null>:
                      but is
@@ -55,7 +55,7 @@ public partial class EnumerableAssertTest
         // should fail because the current is null
         AssertThrown(() => AssertArray(null).IsNotNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 56)
+            .HasFileLineNumber(56)
             .HasMessage("Expecting be NOT <Null>:");
     }
 
@@ -71,7 +71,7 @@ public partial class EnumerableAssertTest
 
         AssertThrown(() => AssertArray(new int[] { 1, 2, 4, 5 }).IsEqual(new int[] { 1, 2, 3, 4, 2, 5 }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 72)
+            .HasFileLineNumber(72)
             .HasMessage("""
                     Expecting be equal:
                         [1, 2, 3, 4, 2, 5]
@@ -80,7 +80,7 @@ public partial class EnumerableAssertTest
                     """);
         AssertThrown(() => AssertArray(new Godot.Collections.Array(new Variant[] { 1, 2, 4, 5 })).IsEqual(new Godot.Collections.Array(new Variant[] { 1, 2, 3, 4, 2, 5 })))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 81)
+            .HasFileLineNumber(81)
             .HasMessage("""
                     Expecting be equal:
                         [1, 2, 3, 4, 2, 5]
@@ -89,7 +89,7 @@ public partial class EnumerableAssertTest
                     """);
         AssertThrown(() => AssertArray(null).IsEqual(Array.Empty<object>()))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 90)
+            .HasFileLineNumber(90)
             .HasMessage("""
                     Expecting be equal:
                         <Empty>
@@ -106,7 +106,7 @@ public partial class EnumerableAssertTest
         AssertThrown(() => AssertArray(new string[] { "this", "is", "a", "message" })
                 .IsEqualIgnoringCase(new string[] { "This", "is", "an", "Message" }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 106)
+            .HasFileLineNumber(106)
             .HasMessage("""
                     Expecting be equal (ignoring case):
                         ["This", "is", "an", "Message"]
@@ -116,7 +116,7 @@ public partial class EnumerableAssertTest
         AssertThrown(() => AssertArray(null)
                .IsEqualIgnoringCase(new string[] { "This", "is" }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 116)
+            .HasFileLineNumber(116)
             .HasMessage("""
                     Expecting be equal (ignoring case):
                         ["This", "is"]
@@ -133,7 +133,7 @@ public partial class EnumerableAssertTest
         // should fail because the array  contains same elements
         AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).IsNotEqual(new int[] { 1, 2, 3, 4, 5 }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 134)
+            .HasFileLineNumber(134)
             .HasMessage("""
                     Expecting be NOT equal:
                         [1, 2, 3, 4, 5]
@@ -151,7 +151,7 @@ public partial class EnumerableAssertTest
         AssertThrown(() => AssertArray(new string[] { "this", "is", "a", "message" })
                 .IsNotEqualIgnoringCase(new string[] { "This", "is", "a", "Message" }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 151)
+            .HasFileLineNumber(151)
             .HasMessage("""
                     Expecting be NOT equal (ignoring case):
                         ["This", "is", "a", "Message"]
@@ -167,14 +167,14 @@ public partial class EnumerableAssertTest
         // should fail because the array is not empty it has a size of one
         AssertThrown(() => AssertArray(new int[] { 1 }).IsEmpty())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 168)
+            .HasFileLineNumber(168)
             .HasMessage("""
                     Expecting be empty:
                      but has size '1'
                     """);
         AssertThrown(() => AssertArray(null).IsEmpty())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 175)
+            .HasFileLineNumber(175)
             .HasMessage("""
                     Expecting be empty:
                      but is <Null>
@@ -189,7 +189,7 @@ public partial class EnumerableAssertTest
         // should fail because the array is empty
         AssertThrown(() => AssertArray(Array.Empty<int>()).IsNotEmpty())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 190)
+            .HasFileLineNumber(190)
             .HasMessage("""
                     Expecting being NOT empty:
                      but is empty
@@ -204,14 +204,14 @@ public partial class EnumerableAssertTest
         // should fail because the array has a size of 5
         AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).HasSize(4))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 205)
+            .HasFileLineNumber(205)
             .HasMessage("""
                     Expecting size:
                         '4' but is '5'
                     """);
         AssertThrown(() => AssertArray(null).HasSize(4))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 212)
+            .HasFileLineNumber(212)
             .HasMessage("""
                     Expecting size:
                         '4' but is unknown
@@ -227,7 +227,7 @@ public partial class EnumerableAssertTest
         // should fail because the array not contains 'xxx' and 'yyy'
         AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).Contains(new string[] { "bbb", "xxx", "yyy" }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 228)
+            .HasFileLineNumber(228)
             .HasMessage("""
                     Expecting contains elements:
                         ["aaa", "bbb", "ccc", "ddd", "eee"]
@@ -238,7 +238,7 @@ public partial class EnumerableAssertTest
                     """);
         AssertThrown(() => AssertArray(null).Contains(new string[] { "bbb", "xxx", "yyy" }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 239)
+            .HasFileLineNumber(239)
             .HasMessage("""
                     Expecting contains elements:
                         <Null>
@@ -258,7 +258,7 @@ public partial class EnumerableAssertTest
         // should fail because the array not contains 7 and 6
         AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).Contains("bbb", "xxx", "yyy"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 259)
+            .HasFileLineNumber(259)
             .HasMessage("""
                     Expecting contains elements:
                         ["aaa", "bbb", "ccc", "ddd", "eee"]
@@ -278,7 +278,7 @@ public partial class EnumerableAssertTest
         // should fail because the array not contains 7 and 6
         AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).Contains(new int[] { 2, 7, 6 }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 279)
+            .HasFileLineNumber(279)
             .HasMessage("""
                     Expecting contains elements:
                         [1, 2, 3, 4, 5]
@@ -298,7 +298,7 @@ public partial class EnumerableAssertTest
         // should fail because the array not contains 7 and 6
         AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).Contains(2, 7, 6))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 299)
+            .HasFileLineNumber(299)
             .HasMessage("""
                     Expecting contains elements:
                         [1, 2, 3, 4, 5]
@@ -316,7 +316,7 @@ public partial class EnumerableAssertTest
         AssertArray(new string[] { "abc" }).ContainsExactly(new string[] { "abc" });
         AssertThrown(() => AssertArray(new string[] { "abc" }).ContainsExactly(new string[] { "abXc" }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 317)
+            .HasFileLineNumber(317)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["abc"]
@@ -333,7 +333,7 @@ public partial class EnumerableAssertTest
         // should fail because if contains the same elements but in a different order
         AssertThrown(() => AssertArray(new string[] { "abc", "def", "xyz" }).ContainsExactly(new string[] { "abc", "xyz", "def" }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 334)
+            .HasFileLineNumber(334)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["abc", "def", "xyz"]
@@ -346,7 +346,7 @@ public partial class EnumerableAssertTest
         // should fail because it contains more elements and in a different order
         AssertThrown(() => AssertArray(new string[] { "abc", "def", "foo", "bar", "xyz" }).ContainsExactly(new string[] { "abc", "xyz", "def" }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 347)
+            .HasFileLineNumber(347)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["abc", "def", "foo", "bar", "xyz"]
@@ -359,7 +359,7 @@ public partial class EnumerableAssertTest
         // should fail because it contains less elements and in a different order
         AssertThrown(() => AssertArray(new string[] { "abc", "def", "xyz" }).ContainsExactly(new string[] { "abc", "def", "bar", "foo", "xyz" }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 360)
+            .HasFileLineNumber(360)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["abc", "def", "xyz"]
@@ -370,7 +370,7 @@ public partial class EnumerableAssertTest
                     """);
         AssertThrown(() => AssertArray(null).ContainsExactly(new string[] { "abc", "def", "bar", "foo", "xyz" }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 371)
+            .HasFileLineNumber(371)
             .HasMessage("""
                     Expecting contains exactly elements:
                         <Null>
@@ -388,7 +388,7 @@ public partial class EnumerableAssertTest
         AssertArray(new string[] { "abc" }).ContainsExactly("abc");
         AssertThrown(() => AssertArray(new string[] { "abc" }).ContainsExactly("abXc"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 389)
+            .HasFileLineNumber(389)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["abc"]
@@ -404,7 +404,7 @@ public partial class EnumerableAssertTest
         // should fail because if contains the same elements but in a different order
         AssertThrown(() => AssertArray(new string[] { "abc", "def", "xyz" }).ContainsExactly("abc", "xyz", "def"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 405)
+            .HasFileLineNumber(405)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["abc", "def", "xyz"]
@@ -416,7 +416,7 @@ public partial class EnumerableAssertTest
         // should fail because it contains more elements and in a different order
         AssertThrown(() => AssertArray(new string[] { "abc", "def", "foo", "bar", "xyz" }).ContainsExactly("abc", "xyz", "def"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 417)
+            .HasFileLineNumber(417)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["abc", "def", "foo", "bar", "xyz"]
@@ -428,7 +428,7 @@ public partial class EnumerableAssertTest
         // should fail because it contains less elements and in a different order
         AssertThrown(() => AssertArray(new string[] { "abc", "def", "xyz" }).ContainsExactly("abc", "def", "bar", "foo", "xyz"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 429)
+            .HasFileLineNumber(429)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["abc", "def", "xyz"]
@@ -446,7 +446,7 @@ public partial class EnumerableAssertTest
         AssertArray(new int[] { 1 }).ContainsExactly(new int[] { 1 });
         AssertThrown(() => AssertArray(new int[] { 1 }).ContainsExactly(new int[] { 2 }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 447)
+            .HasFileLineNumber(447)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1]
@@ -462,7 +462,7 @@ public partial class EnumerableAssertTest
         // should fail because if contains the same elements but in a different order
         AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactly(new int[] { 1, 4, 3, 2, 5 }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 463)
+            .HasFileLineNumber(463)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1, 2, 3, 4, 5]
@@ -474,7 +474,7 @@ public partial class EnumerableAssertTest
         // should fail because it contains more elements and in a different order
         AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5, 6, 7 }).ContainsExactly(new int[] { 1, 4, 3, 2, 5 }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 475)
+            .HasFileLineNumber(475)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1, 2, 3, 4, 5, 6, 7]
@@ -486,7 +486,7 @@ public partial class EnumerableAssertTest
         // should fail because it contains less elements and in a different order
         AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactly(new int[] { 1, 4, 3, 2, 5, 6, 7 }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 487)
+            .HasFileLineNumber(487)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1, 2, 3, 4, 5]
@@ -504,7 +504,7 @@ public partial class EnumerableAssertTest
         AssertArray(new int[] { 1 }).ContainsExactly(1);
         AssertThrown(() => AssertArray(new int[] { 1 }).ContainsExactly(2))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 505)
+            .HasFileLineNumber(505)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1]
@@ -520,7 +520,7 @@ public partial class EnumerableAssertTest
         // should fail because if contains the same elements but in a different order
         AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactly(1, 4, 3, 2, 5))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 521)
+            .HasFileLineNumber(521)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1, 2, 3, 4, 5]
@@ -532,7 +532,7 @@ public partial class EnumerableAssertTest
         // should fail because it contains more elements and in a different order
         AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5, 6, 7 }).ContainsExactly(1, 4, 3, 2, 5))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 533)
+            .HasFileLineNumber(533)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1, 2, 3, 4, 5, 6, 7]
@@ -544,7 +544,7 @@ public partial class EnumerableAssertTest
         // should fail because it contains less elements and in a different order
         AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactly(1, 4, 3, 2, 5, 6, 7))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 545)
+            .HasFileLineNumber(545)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1, 2, 3, 4, 5]
@@ -566,7 +566,7 @@ public partial class EnumerableAssertTest
         AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd" })
                 .ContainsExactlyInAnyOrder(new string[] { "xxx", "aaa", "yyy", "bbb", "ccc", "ddd" }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 566)
+            .HasFileLineNumber(566)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["aaa", "bbb", "ccc", "ddd"]
@@ -579,7 +579,7 @@ public partial class EnumerableAssertTest
         AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee", "fff" })
                 .ContainsExactlyInAnyOrder(new string[] { "fff", "aaa", "ddd", "bbb", "eee", }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 579)
+            .HasFileLineNumber(579)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["aaa", "bbb", "ccc", "ddd", "eee", "fff"]
@@ -591,7 +591,7 @@ public partial class EnumerableAssertTest
         AssertThrown(() => AssertArray(null)
                 .ContainsExactlyInAnyOrder(new string[] { "fff", "aaa", "ddd", "bbb", "eee", }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 591)
+            .HasFileLineNumber(591)
             .HasMessage("""
                     Expecting contains exactly elements:
                         <Null>
@@ -613,7 +613,7 @@ public partial class EnumerableAssertTest
         AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd" })
                 .ContainsExactlyInAnyOrder("xxx", "aaa", "yyy", "bbb", "ccc", "ddd"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 613)
+            .HasFileLineNumber(613)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["aaa", "bbb", "ccc", "ddd"]
@@ -626,7 +626,7 @@ public partial class EnumerableAssertTest
         AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee", "fff" })
                 .ContainsExactlyInAnyOrder("fff", "aaa", "ddd", "bbb", "eee"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 626)
+            .HasFileLineNumber(626)
             .HasMessage("""
                     Expecting contains exactly elements:
                         ["aaa", "bbb", "ccc", "ddd", "eee", "fff"]
@@ -647,7 +647,7 @@ public partial class EnumerableAssertTest
         // should fail because is contains not exactly the same elements in any order
         AssertThrown(() => AssertArray(new int[] { 1, 2, 6, 4, 5 }).ContainsExactlyInAnyOrder(new int[] { 5, 3, 2, 4, 1, 9, 10 }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 648)
+            .HasFileLineNumber(648)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1, 2, 6, 4, 5]
@@ -661,7 +661,7 @@ public partial class EnumerableAssertTest
         //should fail because is contains the same elements but in a different order
         AssertThrown(() => AssertArray(new int[] { 1, 2, 6, 9, 10, 4, 5 }).ContainsExactlyInAnyOrder(new int[] { 5, 3, 2, 4, 1 }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 662)
+            .HasFileLineNumber(662)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1, 2, 6, 9, 10, 4, 5]
@@ -684,7 +684,7 @@ public partial class EnumerableAssertTest
         // should fail because is contains not exactly the same elements in any order
         AssertThrown(() => AssertArray(new int[] { 1, 2, 6, 4, 5 }).ContainsExactlyInAnyOrder(5, 3, 2, 4, 1, 9, 10))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 685)
+            .HasFileLineNumber(685)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1, 2, 6, 4, 5]
@@ -698,7 +698,7 @@ public partial class EnumerableAssertTest
         //should fail because is contains the same elements but in a different order
         AssertThrown(() => AssertArray(new int[] { 1, 2, 6, 9, 10, 4, 5 }).ContainsExactlyInAnyOrder(5, 3, 2, 4, 1))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 699)
+            .HasFileLineNumber(699)
             .HasMessage("""
                     Expecting contains exactly elements:
                         [1, 2, 6, 9, 10, 4, 5]
@@ -742,7 +742,7 @@ public partial class EnumerableAssertTest
         // must fail we can't extract from a null instance
         AssertThrown(() => AssertArray(null).Extract("GetClass").ContainsExactly("AStar", "Node"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 743)
+            .HasFileLineNumber(743)
             .HasMessage("""
                     Expecting contains exactly elements:
                         <Null>
@@ -799,7 +799,7 @@ public partial class EnumerableAssertTest
                 .ExtractV(Extr("GetName"), Extr("GetValue"), Extr("GetX"))
                 .ContainsExactly(Tuple("A", 10, null)))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 798)
+            .HasFileLineNumber(798)
             .HasMessage("""
                     Expecting contains exactly elements:
                         <Null>
@@ -885,7 +885,7 @@ public partial class EnumerableAssertTest
                 .OverrideFailureMessage("Custom failure message")
                 .IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 884)
+            .HasFileLineNumber(884)
             .HasMessage("Custom failure message");
 
     [TestCase]

--- a/test/src/asserts/ExceptionAssertTest.cs
+++ b/test/src/asserts/ExceptionAssertTest.cs
@@ -1,0 +1,111 @@
+namespace GdUnit4.Tests.Asserts;
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+using GdUnit4.Asserts;
+
+using static Assertions;
+using static Utils;
+
+[TestSuite]
+public class ExceptionAssertTest
+{
+
+    private static IStringAssert AssertStackTrace(IExceptionAssert? exceptionAssert, int frame)
+    {
+        var stackTrace = (exceptionAssert as ExceptionAssert<Exception>)?.GetExceptionStackTrace();
+        var stackFrames = stackTrace!.Split('\n');
+
+        return AssertThat(stackFrames?[frame]);
+    }
+
+    [TestCase]
+    public async Task TestCaseInnerException()
+    {
+        AssertThat(true).IsTrue();
+        var assertion = AssertThrown(() => AssertThat(true).IsFalse())
+            .HasFileLineNumber(28)
+            .HasFileName("src/asserts/ExceptionAssertTest.cs");
+        AssertStackTrace(assertion, 1)
+            .Contains("at GdUnit4.Tests.Asserts.ExceptionAssertTest.TestCaseInnerException()")
+            .Contains("src\\asserts\\ExceptionAssertTest.cs:line 28".Replace('\\', Path.DirectorySeparatorChar));
+        AssertThrown(()
+            => AssertThat(true)
+                .IsFalse())
+            .HasFileLineNumber(35)
+            .HasFileName("src/asserts/ExceptionAssertTest.cs");
+        // do a context switch
+        await DoWait(100);
+        AssertThrown(()
+            => AssertThat(true)
+                .IsFalse())
+            .HasFileLineNumber(42)
+            .HasFileName("src/asserts/ExceptionAssertTest.cs");
+        // do a Godot frame context switch
+        await ISceneRunner.SyncProcessFrame;
+        AssertThrown(()
+            => AssertThat(true)
+                .IsFalse())
+            .HasFileLineNumber(49)
+            .HasFileName("src/asserts/ExceptionAssertTest.cs");
+    }
+
+    [TestCase]
+    public async Task TestCaseInnerMethodException()
+    {
+        await ISceneRunner.SyncProcessFrame;
+        // we want to collect the stack trace inclusive sub method calls and this failure line number
+        // https://github.com/MikeSchulze/gdUnit4Mono/issues/49
+        var assertion = AssertThrown(() => AssertInner(0, true, true))
+            .HasFileLineNumber(73)
+            .HasFileName("src/asserts/ExceptionAssertTest.cs");
+        AssertStackTrace(assertion, 0)
+            .Contains("src\\asserts\\ExceptionAssertTest.cs:line 73".Replace('\\', Path.DirectorySeparatorChar));
+        AssertStackTrace(assertion, 1)
+            .Contains("src\\asserts\\ExceptionAssertTest.cs:line 61".Replace('\\', Path.DirectorySeparatorChar));
+
+        static void AssertInner(int val, bool isEven, bool isOdd)
+        {
+            AssertBool(val % 2 == 0).IsEqual(isEven);
+            // this line should be reported as failure
+            AssertBool(val % 2 != 0).IsEqual(isOdd);
+        }
+    }
+
+    private static void DoAssert(int val, bool isEven, bool isOdd)
+    {
+        AssertBool(val % 2 == 0).IsEqual(isEven);
+        // this line should be reported as failure
+        AssertBool(val % 2 != 0).IsEqual(isOdd);
+    }
+
+    [TestCase]
+    public void TestCaseOuterMethodException()
+    {
+        var assertion = AssertThrown(() => DoAssert(0, true, true))
+            .HasFileLineNumber(81) as ExceptionAssert<Exception>;
+        AssertStackTrace(assertion, 0)
+            .Contains("at GdUnit4.Tests.Asserts.ExceptionAssertTest.DoAssert(Int32 val, Boolean isEven, Boolean isOdd)")
+            .Contains("src\\asserts\\ExceptionAssertTest.cs:line 81".Replace('\\', Path.DirectorySeparatorChar));
+        AssertStackTrace(assertion, 2)
+            .Contains("at GdUnit4.Tests.Asserts.ExceptionAssertTest.TestCaseOuterMethodException()")
+            .Contains("src\\asserts\\ExceptionAssertTest.cs:line 87".Replace('\\', Path.DirectorySeparatorChar));
+    }
+
+    [TestCase]
+    public async Task TestCaseOuterMethodExceptionAndAwait()
+    {
+        await ISceneRunner.SyncProcessFrame;
+        var assertion = AssertThrown(() => DoAssert(0, true, true))
+            .HasFileLineNumber(81)
+            .HasFileName("src/asserts/ExceptionAssertTest.cs") as ExceptionAssert<Exception>;
+        AssertStackTrace(assertion, 0)
+            .Contains("at GdUnit4.Tests.Asserts.ExceptionAssertTest.DoAssert(Int32 val, Boolean isEven, Boolean isOdd)")
+            .Contains("src\\asserts\\ExceptionAssertTest.cs:line 81".Replace('\\', Path.DirectorySeparatorChar));
+        AssertStackTrace(assertion, 2)
+            .Contains("at GdUnit4.Tests.Asserts.ExceptionAssertTest.TestCaseOuterMethodExceptionAndAwait()")
+            .Contains("src\\asserts\\ExceptionAssertTest.cs:line 101".Replace('\\', Path.DirectorySeparatorChar));
+    }
+}

--- a/test/src/asserts/NumberAssertTest.cs
+++ b/test/src/asserts/NumberAssertTest.cs
@@ -13,7 +13,7 @@ public class NumberAssertTest
     public void IsNull()
         => AssertThrown(() => AssertInt(23).IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 14)
+            .HasFileLineNumber(14)
             .HasMessage("""
                 Expecting be <Null>:
                  but is
@@ -37,7 +37,7 @@ public class NumberAssertTest
         // this assertion fails because 23 are not equal to 42
         AssertThrown(() => AssertInt(38).IsEqual(42))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 38)
+            .HasFileLineNumber(38)
             .HasMessage("""
                 Expecting be equal:
                     '42' but is '38'
@@ -52,7 +52,7 @@ public class NumberAssertTest
         // this assertion fails because 23 are equal to 23
         AssertThrown(() => AssertInt(23).IsNotEqual(23))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 53)
+            .HasFileLineNumber(53)
             .HasMessage("""
                 Expecting be NOT equal:
                     '23' but is '23'
@@ -68,28 +68,28 @@ public class NumberAssertTest
         // this assertion fails because 23 is not less than 23
         AssertThrown(() => AssertInt(23).IsLess(23))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 69)
+            .HasFileLineNumber(69)
             .HasMessage("""
                 Expecting to be less than:
                     '23' but is '23'
                 """);
         AssertThrown(() => AssertInt(23).IsLess(22))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 76)
+            .HasFileLineNumber(76)
             .HasMessage("""
                 Expecting to be less than:
                     '22' but is '23'
                 """);
         AssertThrown(() => AssertInt(-23).IsLess(-23))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 83)
+            .HasFileLineNumber(83)
             .HasMessage("""
                 Expecting to be less than:
                     '-23' but is '-23'
                 """);
         AssertThrown(() => AssertInt(-23).IsLess(-24))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 90)
+            .HasFileLineNumber(90)
             .HasMessage("""
                 Expecting to be less than:
                     '-24' but is '-23'
@@ -107,14 +107,14 @@ public class NumberAssertTest
         // this assertion fails because 23 is not less than or equal to 22
         AssertThrown(() => AssertInt(23).IsLessEqual(22)).IsInstanceOf<TestFailedException>()
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 108)
+            .HasFileLineNumber(108)
             .HasMessage("""
                 Expecting to be less than or equal:
                     '22' but is '23'
                 """);
         AssertThrown(() => AssertInt(-23).IsLessEqual(-24))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 115)
+            .HasFileLineNumber(115)
             .HasMessage("""
                 Expecting to be less than or equal:
                     '-24' but is '-23'
@@ -131,28 +131,28 @@ public class NumberAssertTest
         // this assertion fails because 23 is not greater than 23
         AssertThrown(() => AssertInt(23).IsGreater(23))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 132)
+            .HasFileLineNumber(132)
             .HasMessage("""
                 Expecting to be greater than:
                     '23' but is '23'
                 """);
         AssertThrown(() => AssertInt(23).IsGreater(24))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 139)
+            .HasFileLineNumber(139)
             .HasMessage("""
                 Expecting to be greater than:
                     '24' but is '23'
                 """);
         AssertThrown(() => AssertInt(-23).IsGreater(-23))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 146)
+            .HasFileLineNumber(146)
             .HasMessage("""
                 Expecting to be greater than:
                     '-23' but is '-23'
                 """);
         AssertThrown(() => AssertInt(-23).IsGreater(-22))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 153)
+            .HasFileLineNumber(153)
             .HasMessage("""
                 Expecting to be greater than:
                     '-22' but is '-23'
@@ -170,14 +170,14 @@ public class NumberAssertTest
         // this assertion fails because 23 is not greater than 23
         AssertThrown(() => AssertInt(23).IsGreaterEqual(24))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 171)
+            .HasFileLineNumber(171)
             .HasMessage("""
                 Expecting to be greater than or equal:
                     '24' but is '23'
                 """);
         AssertThrown(() => AssertInt(-23).IsGreaterEqual(-22))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 178)
+            .HasFileLineNumber(178)
             .HasMessage("""
                 Expecting to be greater than or equal:
                     '-22' but is '-23'
@@ -195,14 +195,14 @@ public class NumberAssertTest
 
         AssertThrown(() => AssertInt(-13).IsEven())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 196)
+            .HasFileLineNumber(196)
             .HasMessage("""
                 Expecting be even:
                  but is '-13'
                 """);
         AssertThrown(() => AssertInt(13).IsEven())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 203)
+            .HasFileLineNumber(203)
             .HasMessage("""
                 Expecting be even:
                  but is '13'
@@ -216,21 +216,21 @@ public class NumberAssertTest
         AssertInt(13).IsOdd();
         AssertThrown(() => AssertInt(-12).IsOdd())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 217)
+            .HasFileLineNumber(217)
             .HasMessage("""
                 Expecting be odd:
                  but is '-12'
                 """);
         AssertThrown(() => AssertInt(0).IsOdd())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 224)
+            .HasFileLineNumber(224)
             .HasMessage("""
                 Expecting be odd:
                  but is '0'
                 """);
         AssertThrown(() => AssertInt(12).IsOdd())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 231)
+            .HasFileLineNumber(231)
             .HasMessage("""
                 Expecting be odd:
                  but is '12'
@@ -244,14 +244,14 @@ public class NumberAssertTest
         AssertInt(-23).IsNegative();
         AssertThrown(() => AssertInt(0).IsNegative())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 245)
+            .HasFileLineNumber(245)
             .HasMessage("""
                 Expecting be negative:
                  but is '0'
                 """);
         AssertThrown(() => AssertInt(13).IsNegative())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 252)
+            .HasFileLineNumber(252)
             .HasMessage("""
                 Expecting be negative:
                  but is '13'
@@ -265,14 +265,14 @@ public class NumberAssertTest
         AssertInt(13).IsNotNegative();
         AssertThrown(() => AssertInt(-1).IsNotNegative())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 266)
+            .HasFileLineNumber(266)
             .HasMessage("""
                 Expecting be NOT negative:
                  but is '-1'
                 """);
         AssertThrown(() => AssertInt(-13).IsNotNegative())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 273)
+            .HasFileLineNumber(273)
             .HasMessage("""
                 Expecting be NOT negative:
                  but is '-13'
@@ -286,14 +286,14 @@ public class NumberAssertTest
         // this assertion fail because the value is not zero
         AssertThrown(() => AssertInt(-1).IsZero())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 287)
+            .HasFileLineNumber(287)
             .HasMessage("""
                 Expecting be zero:
                  but is '-1'
                 """);
         AssertThrown(() => AssertInt(1).IsZero())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 294)
+            .HasFileLineNumber(294)
             .HasMessage("""
                 Expecting be zero:
                  but is '1'
@@ -308,7 +308,7 @@ public class NumberAssertTest
         // this assertion fail because the value is not zero
         AssertThrown(() => AssertInt(0).IsNotZero())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 309)
+            .HasFileLineNumber(309)
             .HasMessage("""
                 Expecting be NOT zero:
                  but is '0'
@@ -323,7 +323,7 @@ public class NumberAssertTest
         // this assertion fail because 7 is not in [3, 4, 5, 6]
         AssertThrown(() => AssertInt(7).IsIn(new int[] { 3, 4, 5, 6 }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 324)
+            .HasFileLineNumber(324)
             .HasMessage("""
                 Expecting:
                     '7'
@@ -332,7 +332,7 @@ public class NumberAssertTest
                 """);
         AssertThrown(() => AssertInt(7).IsIn(Array.Empty<int>()))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 333)
+            .HasFileLineNumber(333)
             .HasMessage("""
                 Expecting:
                     '7'
@@ -351,7 +351,7 @@ public class NumberAssertTest
         // this assertion fail because 7 is not in [3, 4, 5, 6]
         AssertThrown(() => AssertInt(5).IsNotIn(new int[] { 3, 4, 5, 6 }))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 352)
+            .HasFileLineNumber(352)
             .HasMessage("""
                 Expecting:
                     '5'
@@ -369,7 +369,7 @@ public class NumberAssertTest
     {
         AssertThrown(() => AssertInt(-10).IsBetween(-9, 0))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 370)
+            .HasFileLineNumber(370)
             .HasMessage("""
                 Expecting:
                     '-10'
@@ -378,7 +378,7 @@ public class NumberAssertTest
                 """);
         AssertThrown(() => AssertInt(0).IsBetween(1, 10))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 379)
+            .HasFileLineNumber(379)
             .HasMessage("""
                 Expecting:
                     '0'
@@ -387,7 +387,7 @@ public class NumberAssertTest
                 """);
         AssertThrown(() => AssertInt(10).IsBetween(11, 21))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 388)
+            .HasFileLineNumber(388)
             .HasMessage("""
                 Expecting:
                     '10'
@@ -402,7 +402,7 @@ public class NumberAssertTest
                 .OverrideFailureMessage("Custom failure message")
                 .IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 401)
+            .HasFileLineNumber(401)
             .HasMessage("Custom failure message");
 
     [TestCase]

--- a/test/src/asserts/ObjectAssertTest.cs
+++ b/test/src/asserts/ObjectAssertTest.cs
@@ -32,12 +32,12 @@ public class ObjectAssertTest
         // should fail because the current is an CubeMesh and we expect equal to a Skin
         AssertThrown(() => AssertObject(new Godot.BoxMesh()).IsEqual(new Godot.Skin()))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 33)
+            .HasFileLineNumber(33)
             .HasMessage("Expecting be equal:\n"
                 + "    <Godot.Skin> but is <Godot.BoxMesh>");
         AssertThrown(() => AssertObject(new object()).IsEqual(new List<int>()))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 38)
+            .HasFileLineNumber(38)
             .HasMessage("Expecting be equal:\n"
                 + "    <Empty>\n"
                 + " but is\n"
@@ -53,12 +53,12 @@ public class ObjectAssertTest
         // should fail because the current is an CubeMesh and we expect not equal to a CubeMesh
         AssertThrown(() => AssertObject(new Godot.BoxMesh()).IsNotEqual(new Godot.BoxMesh()))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 54)
+            .HasFileLineNumber(54)
             .HasMessage("Expecting be NOT equal:\n"
                 + "    <Godot.BoxMesh> but is <Godot.BoxMesh>");
         AssertThrown(() => AssertObject(o).IsNotEqual(o))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 59)
+            .HasFileLineNumber(59)
             .HasMessage("Expecting be NOT equal:\n"
                 + "    <System.Object> but is <System.Object>");
     }
@@ -83,17 +83,17 @@ public class ObjectAssertTest
         // should fail because the current is not a instance of `Tree`
         AssertThrown(() => AssertObject(AutoFree(new Godot.Path2D())).IsInstanceOf<Godot.Tree>())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 84)
+            .HasFileLineNumber(84)
             .HasMessage("Expected be instance of:\n"
                 + "    <Godot.Tree> but is <Godot.Path2D>");
         AssertThrown(() => AssertObject(null).IsInstanceOf<Godot.Tree>())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 89)
+            .HasFileLineNumber(89)
             .HasMessage("Expected be instance of:\n"
                 + "    <Godot.Tree> but is <Null>");
         AssertThrown(() => AssertObject(new CustomClass()).IsInstanceOf<CustomClassB>())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 94)
+            .HasFileLineNumber(94)
             .HasMessage("Expected be instance of:\n"
                 + "    <GdUnit4.Tests.Asserts.CustomClassB> but is <GdUnit4.Tests.Asserts.CustomClass>");
     }
@@ -113,12 +113,12 @@ public class ObjectAssertTest
         // should fail because the current is not a instance of `Tree`
         AssertThrown(() => AssertObject(AutoFree(new Godot.Path2D())).IsNotInstanceOf<Godot.Node>())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 114)
+            .HasFileLineNumber(114)
             .HasMessage("Expecting be NOT a instance of:\n"
                 + "    <Godot.Node>");
         AssertThrown(() => AssertObject(AutoFree(new CustomClassB())).IsNotInstanceOf<CustomClass>())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 119)
+            .HasFileLineNumber(119)
             .HasMessage("Expecting be NOT a instance of:\n"
                 + "    <GdUnit4.Tests.Asserts.CustomClass>");
     }
@@ -130,13 +130,13 @@ public class ObjectAssertTest
         // should fail because the current is not null
         AssertThrown(() => AssertObject(AutoFree(new Godot.Node())).IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 131)
+            .HasFileLineNumber(131)
             .StartsWithMessage("Expecting be <Null>:\n"
                 + " but is\n"
                 + "    <Godot.Node>");
         AssertThrown(() => AssertObject(new object()).IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 137)
+            .HasFileLineNumber(137)
             .StartsWithMessage("Expecting be <Null>:\n"
                 + " but is\n"
                 + "    <System.Object>");
@@ -150,7 +150,7 @@ public class ObjectAssertTest
         // should fail because the current is null
         AssertThrown(() => AssertObject(null).IsNotNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 151)
+            .HasFileLineNumber(151)
             .HasMessage("Expecting be NOT <Null>:");
     }
 
@@ -171,28 +171,28 @@ public class ObjectAssertTest
 
         AssertThrown(() => AssertObject(null).IsSame(obj1))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 172)
+            .HasFileLineNumber(172)
             .HasMessage("Expecting be same:\n"
                 + "    <Godot.Node>\n"
                 + " to refer to the same object\n"
                 + "    <Null>");
         AssertThrown(() => AssertObject(obj1).IsSame(obj3))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 179)
+            .HasFileLineNumber(179)
             .HasMessage("Expecting be same:\n"
                 + "    <Godot.Node>\n"
                 + " to refer to the same object\n"
                 + "    <Godot.Node>");
         AssertThrown(() => AssertObject(obj3).IsSame(obj1))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 186)
+            .HasFileLineNumber(186)
             .HasMessage("Expecting be same:\n"
                 + "    <Godot.Node>\n"
                 + " to refer to the same object\n"
                 + "    <Godot.Node>");
         AssertThrown(() => AssertObject(obj3).IsSame(obj2))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 193)
+            .HasFileLineNumber(193)
             .HasMessage("Expecting be same:\n"
                 + "    <Godot.Node>\n"
                 + " to refer to the same object\n"
@@ -218,15 +218,15 @@ public class ObjectAssertTest
 
         AssertThrown(() => AssertObject(obj1).IsNotSame(obj1))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 219)
+            .HasFileLineNumber(219)
             .HasMessage("Expecting be NOT same: <Godot.Node>");
         AssertThrown(() => AssertObject(obj1).IsNotSame(obj2))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 223)
+            .HasFileLineNumber(223)
             .HasMessage("Expecting be NOT same: <Godot.Node>");
         AssertThrown(() => AssertObject(obj2).IsNotSame(obj1))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 227)
+            .HasFileLineNumber(227)
             .HasMessage("Expecting be NOT same: <Godot.Node>");
     }
 
@@ -235,15 +235,15 @@ public class ObjectAssertTest
     {
         AssertThrown(() => AssertObject(1))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 236)
+            .HasFileLineNumber(236)
             .HasMessage("ObjectAssert initial error: current is primitive <System.Int32>");
         AssertThrown(() => AssertObject(1.3))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 240)
+            .HasFileLineNumber(240)
             .HasMessage("ObjectAssert initial error: current is primitive <System.Double>");
         AssertThrown(() => AssertObject(true))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 244)
+            .HasFileLineNumber(244)
             .HasMessage("ObjectAssert initial error: current is primitive <System.Boolean>");
     }
 
@@ -253,7 +253,7 @@ public class ObjectAssertTest
                 .OverrideFailureMessage("Custom failure message")
                 .IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 252)
+            .HasFileLineNumber(252)
             .HasMessage("Custom failure message");
 
     [TestCase]

--- a/test/src/asserts/StringAssertTest.cs
+++ b/test/src/asserts/StringAssertTest.cs
@@ -15,7 +15,7 @@ public class StringAssertTest
         // should fail because the current is not null
         AssertThrown(() => AssertString("abc").IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 16)
+            .HasFileLineNumber(16)
             .StartsWithMessage("""
                 Expecting be <Null>:
                  but is
@@ -30,7 +30,7 @@ public class StringAssertTest
         // should fail because the current is null
         AssertThrown(() => AssertString(null).IsNotNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 31)
+            .HasFileLineNumber(31)
             .HasMessage("Expecting be NOT <Null>:");
     }
 
@@ -40,7 +40,7 @@ public class StringAssertTest
         AssertString("This is a test message").IsEqual("This is a test message");
         AssertThrown(() => AssertString("This is a test message").IsEqual("This is a test Message"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 41)
+            .HasFileLineNumber(41)
             .HasMessage("""
                 Expecting be equal:
                     "This is a test Message"
@@ -49,7 +49,7 @@ public class StringAssertTest
                 """);
         AssertThrown(() => AssertString(null).IsEqual("This is a test Message"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 50)
+            .HasFileLineNumber(50)
             .HasMessage("""
                 Expecting be equal:
                     "This is a test Message"
@@ -64,7 +64,7 @@ public class StringAssertTest
         AssertString("This is a test message").IsEqualIgnoringCase("This is a test Message");
         AssertThrown(() => AssertString("This is a test message").IsEqualIgnoringCase("This is a Message"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 65)
+            .HasFileLineNumber(65)
             .HasMessage("""
                 Expecting be equal (ignoring case):
                     "This is a Message"
@@ -73,7 +73,7 @@ public class StringAssertTest
                 """);
         AssertThrown(() => AssertString(null).IsEqualIgnoringCase("This is a Message"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 74)
+            .HasFileLineNumber(74)
             .HasMessage("""
                 Expecting be equal (ignoring case):
                     "This is a Message"
@@ -89,7 +89,7 @@ public class StringAssertTest
         AssertString("This is a test message").IsNotEqual("This is a test Message");
         AssertThrown(() => AssertString("This is a test message").IsNotEqual("This is a test message"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 90)
+            .HasFileLineNumber(90)
             .HasMessage("""
                 Expecting be NOT equal:
                     "This is a test message"
@@ -105,7 +105,7 @@ public class StringAssertTest
         AssertString("This is a test message").IsNotEqualIgnoringCase("This is a Message");
         AssertThrown(() => AssertString("This is a test message").IsNotEqualIgnoringCase("This is a test Message"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 106)
+            .HasFileLineNumber(106)
             .HasMessage("""
                 Expecting be NOT equal (ignoring case):
                     "This is a test Message"
@@ -121,7 +121,7 @@ public class StringAssertTest
         // should fail because the current value is not empty it contains a space
         AssertThrown(() => AssertString(" ").IsEmpty())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 122)
+            .HasFileLineNumber(122)
             .HasMessage("""
                 Expecting be empty:
                  but is
@@ -129,7 +129,7 @@ public class StringAssertTest
                 """);
         AssertThrown(() => AssertString("abc").IsEmpty())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 130)
+            .HasFileLineNumber(130)
             .HasMessage("""
                 Expecting be empty:
                  but is
@@ -137,7 +137,7 @@ public class StringAssertTest
                 """);
         AssertThrown(() => AssertString(null).IsEmpty())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 138)
+            .HasFileLineNumber(138)
             .HasMessage("""
                 Expecting be empty:
                  but is
@@ -155,7 +155,7 @@ public class StringAssertTest
         // should fail because current is empty
         AssertThrown(() => AssertString("").IsNotEmpty())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 156)
+            .HasFileLineNumber(156)
             .HasMessage("""
                 Expecting being NOT empty:
                  but is empty
@@ -169,7 +169,7 @@ public class StringAssertTest
         // must fail because of camel case difference
         AssertThrown(() => AssertString("This is a test message").Contains("a Test"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 170)
+            .HasFileLineNumber(170)
             .HasMessage("""
                 Expecting:
                     "This is a test message"
@@ -178,7 +178,7 @@ public class StringAssertTest
                 """);
         AssertThrown(() => AssertString(null).Contains("a Test"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 179)
+            .HasFileLineNumber(179)
             .HasMessage("""
                 Expecting:
                     <Null>
@@ -194,7 +194,7 @@ public class StringAssertTest
         AssertString("This is a test message").NotContains("a text");
         AssertThrown(() => AssertString("This is a test message").NotContains("a test"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 195)
+            .HasFileLineNumber(195)
             .HasMessage("""
                 Expecting:
                     "This is a test message"
@@ -209,7 +209,7 @@ public class StringAssertTest
         AssertString("This is a test message").ContainsIgnoringCase("a Test");
         AssertThrown(() => AssertString("This is a test message").ContainsIgnoringCase("a Text"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 210)
+            .HasFileLineNumber(210)
             .HasMessage("""
                 Expecting:
                     "This is a test message"
@@ -218,7 +218,7 @@ public class StringAssertTest
                 """);
         AssertThrown(() => AssertString(null).ContainsIgnoringCase("a Text"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 219)
+            .HasFileLineNumber(219)
             .HasMessage("""
                 Expecting:
                     <Null>
@@ -234,7 +234,7 @@ public class StringAssertTest
         AssertString("This is a test message").NotContainsIgnoringCase("a Text");
         AssertThrown(() => AssertString("This is a test message").NotContainsIgnoringCase("a Test"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 235)
+            .HasFileLineNumber(235)
             .HasMessage("""
                 Expecting:
                     "This is a test message"
@@ -249,7 +249,7 @@ public class StringAssertTest
         AssertString("This is a test message").StartsWith("This is");
         AssertThrown(() => AssertString("This is a test message").StartsWith("This iss"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 250)
+            .HasFileLineNumber(250)
             .HasMessage("""
                 Expecting:
                     "This is a test message"
@@ -258,7 +258,7 @@ public class StringAssertTest
                 """);
         AssertThrown(() => AssertString("This is a test message").StartsWith("this is"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 259)
+            .HasFileLineNumber(259)
             .HasMessage("""
                 Expecting:
                     "This is a test message"
@@ -267,7 +267,7 @@ public class StringAssertTest
                 """);
         AssertThrown(() => AssertString("This is a test message").StartsWith("test"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 268)
+            .HasFileLineNumber(268)
             .HasMessage("""
                 Expecting:
                     "This is a test message"
@@ -276,7 +276,7 @@ public class StringAssertTest
                 """);
         AssertThrown(() => AssertString(null).StartsWith("test"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 277)
+            .HasFileLineNumber(277)
             .HasMessage("""
                 Expecting:
                     <Null>
@@ -291,7 +291,7 @@ public class StringAssertTest
         AssertString("This is a test message").EndsWith("test message");
         AssertThrown(() => AssertString("This is a test message").EndsWith("tes message"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 292)
+            .HasFileLineNumber(292)
             .HasMessage("""
                 Expecting:
                     "This is a test message"
@@ -300,7 +300,7 @@ public class StringAssertTest
                 """);
         AssertThrown(() => AssertString("This is a test message").EndsWith("a test"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 301)
+            .HasFileLineNumber(301)
             .HasMessage("""
                 Expecting:
                     "This is a test message"
@@ -309,7 +309,7 @@ public class StringAssertTest
                 """);
         AssertThrown(() => AssertString(null).EndsWith("a test"))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 310)
+            .HasFileLineNumber(310)
             .HasMessage("""
                 Expecting:
                     <Null>
@@ -325,14 +325,14 @@ public class StringAssertTest
         AssertString("").HasLength(0);
         AssertThrown(() => AssertString("This is a test message").HasLength(23))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 326)
+            .HasFileLineNumber(326)
             .HasMessage("""
                 Expecting length:
                     '23' but is '22'
                 """);
         AssertThrown(() => AssertString(null).HasLength(23))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 333)
+            .HasFileLineNumber(333)
             .HasMessage("""
                 Expecting length:
                     '23' but is unknown
@@ -346,14 +346,14 @@ public class StringAssertTest
         AssertString("This is a test message").HasLength(42, LESS_THAN);
         AssertThrown(() => AssertString("This is a test message").HasLength(22, LESS_THAN))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 347)
+            .HasFileLineNumber(347)
             .HasMessage("""
                 Expecting length to be less than:
                     '22' but is '22'
                 """);
         AssertThrown(() => AssertString(null).HasLength(22, LESS_THAN))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 354)
+            .HasFileLineNumber(354)
             .HasMessage("""
                 Expecting length to be less than:
                     '22' but is unknown
@@ -367,14 +367,14 @@ public class StringAssertTest
         AssertString("This is a test message").HasLength(23, LESS_EQUAL);
         AssertThrown(() => AssertString("This is a test message").HasLength(21, LESS_EQUAL))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 368)
+            .HasFileLineNumber(368)
             .HasMessage("""
                 Expecting length to be less than or equal:
                     '21' but is '22'
                 """);
         AssertThrown(() => AssertString(null).HasLength(21, LESS_EQUAL))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 375)
+            .HasFileLineNumber(375)
             .HasMessage("""
                 Expecting length to be less than or equal:
                     '21' but is unknown
@@ -387,14 +387,14 @@ public class StringAssertTest
         AssertString("This is a test message").HasLength(21, GREATER_THAN);
         AssertThrown(() => AssertString("This is a test message").HasLength(22, GREATER_THAN))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 388)
+            .HasFileLineNumber(388)
             .HasMessage("""
                 Expecting length to be greater than:
                     '22' but is '22'
                 """);
         AssertThrown(() => AssertString(null).HasLength(22, GREATER_THAN))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 395)
+            .HasFileLineNumber(395)
             .HasMessage("""
                 Expecting length to be greater than:
                     '22' but is unknown
@@ -408,14 +408,14 @@ public class StringAssertTest
         AssertString("This is a test message").HasLength(22, GREATER_EQUAL);
         AssertThrown(() => AssertString("This is a test message").HasLength(23, GREATER_EQUAL))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 409)
+            .HasFileLineNumber(409)
             .HasMessage("""
                 Expecting length to be greater than or equal:
                     '23' but is '22'
                 """);
         AssertThrown(() => AssertString(null).HasLength(23, GREATER_EQUAL))
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 416)
+            .HasFileLineNumber(416)
             .HasMessage("""
                 Expecting length to be greater than or equal:
                     '23' but is unknown
@@ -433,7 +433,7 @@ public class StringAssertTest
     public void OverrideFailureMessage()
         => AssertThrown(() => AssertString("").OverrideFailureMessage("Custom failure message").IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasPropertyValue("LineNumber", 434)
+            .HasFileLineNumber(434)
             .HasMessage("Custom failure message");
 
     [TestCase]

--- a/test/src/asserts/VectorAssertTest.cs
+++ b/test/src/asserts/VectorAssertTest.cs
@@ -35,7 +35,7 @@ public class VectorAssertTest
         AssertThat(Vector2.One).IsBetween(Vector2.Zero, Vector2.One);
         // false test
         AssertThrown(() => AssertThat(new Vector2(0, -.1f)).IsBetween(Vector2.Zero, Vector2.One))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting:
                         '(0, -0.1)'
@@ -59,7 +59,7 @@ public class VectorAssertTest
         AssertThat(new Vector2(1.2f, 1.000001f)).IsEqual(new Vector2(1.2f, 1.000001f));
         // false test
         AssertThrown(() => AssertThat(Vector2.One).IsEqual(new Vector2(1.2f, 1.000001f)))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting be equal:
                         '(1.2, 1.000001)' but is '(1, 1)'
@@ -74,7 +74,7 @@ public class VectorAssertTest
         AssertThat(new Vector2(1.2f, 1.000001f)).IsNotEqual(new Vector2(1.2f, 1.000002f));
         // false test
         AssertThrown(() => AssertThat(new Vector2(1.2f, 1.000001f)).IsNotEqual(new Vector2(1.2f, 1.000001f)))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting be NOT equal:
                         '(1.2, 1.000001)' but is '(1.2, 1.000001)'
@@ -90,7 +90,7 @@ public class VectorAssertTest
 
         // false test
         AssertThrown(() => AssertThat(new Vector2(1.005f, 1f)).IsEqualApprox(Vector2.One, new Vector2(0.004f, 0.004f)))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting:
                         '(1.005, 1)'
@@ -98,7 +98,7 @@ public class VectorAssertTest
                         '(0.996, 0.996)' <> '(1.004, 1.004)'
                     """);
         AssertThrown(() => AssertThat(new Vector2(1f, 0.995f)).IsEqualApprox(Vector2.One, new Vector2(0f, 0.004f)))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting:
                         '(1, 0.995)'
@@ -115,13 +115,13 @@ public class VectorAssertTest
 
         // false test
         AssertThrown(() => AssertThat(Vector2.Zero).IsGreater(Vector2.One))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting to be greater than:
                         '(1, 1)' but is '(0, 0)'
                     """);
         AssertThrown(() => AssertThat(new Vector2(1.2f, 1.000001f)).IsGreater(new Vector2(1.2f, 1.000001f)))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting to be greater than:
                         '(1.2, 1.000001)' but is '(1.2, 1.000001)'
@@ -138,13 +138,13 @@ public class VectorAssertTest
 
         // false test
         AssertThrown(() => AssertThat(Vector2.Zero).IsGreaterEqual(Vector2.One))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting to be greater than or equal:
                         '(1, 1)' but is '(0, 0)'
                     """);
         AssertThrown(() => AssertThat(new Vector2(1.2f, 1.000002f)).IsGreaterEqual(new Vector2(1.2f, 1.000003f)))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting to be greater than or equal:
                         '(1.2, 1.000003)' but is '(1.2, 1.000002)'
@@ -159,13 +159,13 @@ public class VectorAssertTest
 
         // false test
         AssertThrown(() => AssertThat(Vector2.One).IsLess(Vector2.One))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting to be less than:
                         '(1, 1)' but is '(1, 1)'
                     """);
         AssertThrown(() => AssertThat(new Vector2(1.2f, 1.000001f)).IsLess(new Vector2(1.2f, 1.000001f)))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting to be less than:
                         '(1.2, 1.000001)' but is '(1.2, 1.000001)'
@@ -192,13 +192,13 @@ public class VectorAssertTest
 
         // false test
         AssertThrown(() => AssertThat(Vector2.One).IsLessEqual(Vector2.Zero))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting to be less than or equal:
                         '(0, 0)' but is '(1, 1)'
                     """);
         AssertThrown(() => AssertThat(new Vector2(1.2f, 1.000002f)).IsLessEqual(new Vector2(1.2f, 1.000001f)))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting to be less than or equal:
                         '(1.2, 1.000001)' but is '(1.2, 1.000002)'
@@ -211,7 +211,7 @@ public class VectorAssertTest
         AssertThat(new Vector2(1f, 1.0002f)).IsNotBetween(Vector2.Zero, Vector2.One);
         // false test
         AssertThrown(() => AssertThat(Vector2.One).IsNotBetween(Vector2.Zero, Vector2.One))
-            .HasPropertyValue("LineNumber", ExpectedLineNumber())
+            .HasFileLineNumber(ExpectedLineNumber())
             .HasMessage("""
                     Expecting:
                         '(1, 1)'

--- a/testadapter/src/execution/BaseTestExecutor.cs
+++ b/testadapter/src/execution/BaseTestExecutor.cs
@@ -33,7 +33,7 @@ internal abstract class BaseTestExecutor
         var message = args.Data?.Trim();
         if (string.IsNullOrEmpty(message))
             return;
-        // we do log errors to stdout otherwise runing `dotnet test` from console will fail with exit code 1
+        // we do log errors to stdout otherwise running `dotnet test` from console will fail with exit code 1
         frameworkHandle.SendMessage(TestMessageLevel.Informational, $"Error: {message}");
     });
 
@@ -105,7 +105,7 @@ internal abstract class BaseTestExecutor
                     foreach (var report in e.Reports)
                     {
                         testResult.ErrorMessage = report.Message.RichTextNormalize();
-                        testResult.ErrorStackTrace = $"StackTrace    at {testCase.FullyQualifiedName}() in {testCase.CodeFilePath}:line {report.LineNumber}";
+                        testResult.ErrorStackTrace = report.StackTrace;
                     }
                     frameworkHandle.RecordResult(testResult);
                     frameworkHandle.RecordEnd(testCase, testResult.Outcome);


### PR DESCRIPTION
# Why
The stack trace was not complete and misses test execution frames.

# What
- Complete rework on `TestFailedException` to provide now the stack trace.
- Fix some issued detected during refactoring on `ExceptionAssert`
- The `TestReport` do now submit the stack trace and is read on test adapter to fill the `ErrorStackTrace`

![image](https://github.com/MikeSchulze/gdUnit4Mono/assets/347037/ef07a53e-ee63-443d-92c5-7d96663e101d)
