### PR TITLE
GD-10: Complete missing features for `IDictionaryAssert`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
     "selcukermaya.se-csproj-extensions",
     "josefpihrt-vscode.roslynator",
     "streetsidesoftware.code-spell-checker",
-    "DavidAnson.vscode-markdownlint"
+    "DavidAnson.vscode-markdownlint",
+    "Gruntfuggly.todo-tree"
   ]
 }

--- a/api/src/Assertions.cs
+++ b/api/src/Assertions.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Linq;
 
 using Asserts;
 
@@ -58,10 +57,11 @@ public sealed class Assertions
     /// <summary>
     /// An assertion method for all Godot vector types.
     /// </summary>
-    /// <typeparam name="T">The type of Godot vector.</typeparam>
+    /// <typeparam name="TValue">The type of Godot vector.</typeparam>
     /// <param name="vector">The vector value to verify.</param>
     /// <returns>An instance of IVectorAssert for further assertions.</returns>
-    public static IVectorAssert<T> AssertVector<T>(T vector) where T : notnull, IEquatable<T> => new VectorAssert<T>(vector);
+    public static IVectorAssert<TValue> AssertVector<TValue>(TValue vector) where TValue : notnull, IEquatable<TValue>
+        => new VectorAssert<TValue>(vector);
 
     /// <summary>
     /// An Assertion to verify Godot.Vector2 values
@@ -83,7 +83,7 @@ public sealed class Assertions
     /// An Assertion used by test generation to notify the test is not yet implemented
     /// </summary>
     /// <returns></returns>
-    public static bool AssertNotYetImplemented() => throw new Exceptions.TestFailedException("Test not yet implemented!", -1);
+    public static bool AssertNotYetImplemented() => throw new Exceptions.TestFailedException("Test not yet implemented!");
 
     /// <summary>
     /// An Assertion to verify Godot signals
@@ -113,11 +113,16 @@ public sealed class Assertions
     public static INumberAssert<double> AssertThat(double current) => new NumberAssert<double>(current);
     public static INumberAssert<decimal> AssertThat(decimal current) => new NumberAssert<decimal>(current);
 
-
+    /**
+        public static IDictionaryAssert<TKey, TValue> AssertThat<TKey, TValue>(IDictionary? current)
+            where TKey : notnull
+            where TValue : notnull
+            => new DictionaryAssert<TKey, TValue>(current);
+*/
     public static IDictionaryAssert<TKey, TValue> AssertThat<TKey, TValue>(IDictionary<TKey, TValue>? current)
         where TKey : notnull
         where TValue : notnull
-        => new DictionaryAssert<TKey, TValue>(current?.ToDictionary(e => e.Key, e => e.Value));
+        => new DictionaryAssert<TKey, TValue>(current);
 
     public static IDictionaryAssert<Godot.Variant, Godot.Variant> AssertThat(Godot.Collections.Dictionary? current)
        => new DictionaryAssert<Godot.Variant, Godot.Variant>(current);
@@ -152,17 +157,16 @@ public sealed class Assertions
     /// <summary>
     /// A dynamic assertion based on the input type.
     /// </summary>
-    /// <typeparam name="T">The type of the input.</typeparam>
+    /// <typeparam name="TValue">The type of the input.</typeparam>
     /// <param name="current">The input value to be asserted.</param>
     /// <returns>A dynamic assert object that provides assertion methods based on the input type.</returns>
-    public static dynamic AssertThat<T>(T? current)
+    public static dynamic AssertThat<TValue>(TValue? current)
     {
-        var type = typeof(T);
+        var type = typeof(TValue);
+
         if (type == typeof(IDictionary) && current == null)
-        {
-            var assertType = typeof(DictionaryAssert<,>).MakeGenericType(typeof(object), typeof(object));
-            return Activator.CreateInstance(assertType, current)!;
-        }
+            return DictionaryAssert<object, object?>.From(null);
+
         if (current is IDictionary dv)
         {
             if (type.IsGenericType)
@@ -173,9 +177,7 @@ public sealed class Assertions
                 var assertType = typeof(DictionaryAssert<,>).MakeGenericType(keyType, valueType);
                 return Activator.CreateInstance(assertType, dv)!;
             }
-            return new DictionaryAssert<object, object?>(dv
-                .Cast<DictionaryEntry>()
-                .ToDictionary(entry => entry.Key, entry => entry.Value));
+            return DictionaryAssert<object, object?>.From(dv);
         }
 
         if (current is IEnumerable ev)
@@ -203,7 +205,7 @@ public sealed class Assertions
     /// </summary>
     /// <param name="task">A task where throw possible exceptions</param>
     /// <returns>a task of <c>IExceptionAssert</c> to await</returns>
-    public static async Task<IExceptionAssert?> AssertThrown<T>(Task<T> task)
+    public static async Task<IExceptionAssert?> AssertThrown<TAction>(Task<TAction> task)
     {
         try
         {
@@ -212,7 +214,7 @@ public sealed class Assertions
         }
         catch (Exception e)
         {
-            return new ExceptionAssert<T>(e);
+            return new ExceptionAssert<Exception>(e);
         }
     }
 
@@ -225,7 +227,7 @@ public sealed class Assertions
         }
         catch (Exception e)
         {
-            return new ExceptionAssert<object>(e);
+            return new ExceptionAssert<Exception>(e);
         }
     }
 
@@ -235,7 +237,7 @@ public sealed class Assertions
     /// Adds the Node on actual SceneTree to be processed during test execution.
     /// The node is auto freed and can be disabled by set autoFree = false.
     /// </summary>
-    public static T AddNode<T>(T node, bool autoFree = true) where T : Godot.Node
+    public static TNode AddNode<TNode>(TNode node, bool autoFree = true) where TNode : Godot.Node
     {
         if (autoFree)
             AutoFree(node);
@@ -247,7 +249,8 @@ public sealed class Assertions
     ///<summary>
     /// A little helper to auto freeing your created objects after test execution
     /// </summary>
-    public static T? AutoFree<T>(T? obj) where T : Godot.GodotObject => Executions.Monitors.MemoryPool.RegisterForAutoFree(obj);
+    public static TValue? AutoFree<TValue>(TValue? obj) where TValue : Godot.GodotObject
+        => Executions.Monitors.MemoryPool.RegisterForAutoFree(obj);
 
     /// <summary>
     /// Builds a tuple by given values

--- a/api/src/IDictionyryAssert.cs
+++ b/api/src/IDictionyryAssert.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 
 /// <summary> An Assertion Tool to verify dictionary values </summary>
-public interface IDictionaryAssert<TKey, TValue> : IAssertBase<IDictionary<TKey, TValue>> where TKey : notnull
+public interface IDictionaryAssert<TKey, TValue> : IAssertBase<IEnumerable> where TKey : notnull
 {
     /// <summary> Verifies that the current dictionary is empty, it has a size of 0.</summary>
     public IDictionaryAssert<TKey, TValue> IsEmpty();
@@ -25,8 +25,61 @@ public interface IDictionaryAssert<TKey, TValue> : IAssertBase<IDictionary<TKey,
     public IDictionaryAssert<TKey, TValue> NotContainsKeys(params TKey[] expected);
     public IDictionaryAssert<TKey, TValue> NotContainsKeys(IEnumerable expected);
 
+    /// <summary>
+    /// Verifies that the current dictionary not contains the given key(s) by object reference
+    /// </summary>
+    /// <remarks>
+    /// The key and value are compared by object reference, for deep parameter comparison use <see cref="NotContainsKeys"/>
+    /// </remarks>
+    /// <param name="expected"></param>
+    /// <returns></returns>
+    public IDictionaryAssert<TKey, TValue> NotContainsSameKeys(params TKey[] expected);
+    public IDictionaryAssert<TKey, TValue> NotContainsSameKeys(IEnumerable expected);
+
     /// <summary> Verifies that the current dictionary contains the given key and value.</summary>
     public IDictionaryAssert<TKey, TValue> ContainsKeyValue(TKey key, TValue value);
 
+    /// <summary>
+    /// Verifies that the current dictionary contains the given key(s) by object reference
+    /// </summary>
+    /// <remarks>
+    /// The key and value are compared by object reference, for deep parameter comparison use <see cref="ContainsKeys"/>
+    /// </remarks>
+    /// <param name="expected"></param>
+    /// <returns></returns>
+    public IDictionaryAssert<TKey, TValue> ContainsSameKeys(params TKey[] expected);
+    public IDictionaryAssert<TKey, TValue> ContainsSameKeys(IEnumerable expected);
+
+    /// <summary>
+    /// Verifies that the current dictionary contains the given key and value by object reference.
+    /// </summary>
+    /// <remarks>
+    /// The key and value are compared by object reference, for deep parameter comparison use <see cref="ContainsKeyValue"/>
+    /// </remarks>
+    /// <returns></returns>
+    public IDictionaryAssert<TKey, TValue> ContainsSameKeyValue(TKey key, TValue value);
+
     public new IDictionaryAssert<TKey, TValue> OverrideFailureMessage(string message);
+
+    /// <summary>
+    /// Verifies that the current dictionary is the same.
+    /// </summary>
+    /// <remarks>
+    /// Compares the current by object reference equals.
+    /// </remarks>
+    /// <param name="expected"></param>
+    public IDictionaryAssert<TKey, TValue> IsSame(IDictionary<TKey, TValue> expected);
+    public IDictionaryAssert<TKey, TValue> IsSame(IEnumerable expected);
+
+    /// <summary>
+    /// Verifies that the current dictionary is NOT the same.
+    /// </summary>
+    /// <remarks>
+    /// Compares the current by object reference equals.
+    /// </remarks>
+    /// <param name="expected"></param>
+    /// <returns></returns>
+    public IDictionaryAssert<TKey, TValue> IsNotSame(IDictionary<TKey, TValue> expected);
+    public IDictionaryAssert<TKey, TValue> IsNotSame(IEnumerable expected);
+
 }

--- a/api/src/asserts/AssertBase.cs
+++ b/api/src/asserts/AssertBase.cs
@@ -27,6 +27,7 @@ internal abstract class AssertBase<TValue> : IAssertBase<TValue>
             ThrowTestFailureReport(AssertFailures.IsNotEqual(Current, expected), Current, expected);
         return this;
     }
+
     public IAssertBase<TValue> IsNull()
     {
         if (Current != null)

--- a/api/src/asserts/BoolAssert.cs
+++ b/api/src/asserts/BoolAssert.cs
@@ -21,8 +21,5 @@ internal sealed class BoolAssert : AssertBase<bool>, IBoolAssert
     }
 
     public new IBoolAssert OverrideFailureMessage(string message)
-    {
-        base.OverrideFailureMessage(message);
-        return this;
-    }
+        => (IBoolAssert)base.OverrideFailureMessage(message);
 }

--- a/api/src/asserts/DictionaryAssert.cs
+++ b/api/src/asserts/DictionaryAssert.cs
@@ -1,80 +1,189 @@
 namespace GdUnit4.Asserts;
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
+using CommandLine;
 
-internal sealed class DictionaryAssert<TKey, TValue> : AssertBase<IDictionary<TKey, TValue>>, IDictionaryAssert<TKey, TValue> where TKey : notnull
+internal sealed class DictionaryAssert<TKey, TValue> : AssertBase<IEnumerable>, IDictionaryAssert<TKey, TValue> where TKey : notnull
 {
+
+    private bool IsGeneric => CurrentTyped != null;
+
+    private new IDictionary? Current => base.Current as IDictionary;
+
+    private IDictionary<TKey, TValue>? CurrentTyped => base.Current as IDictionary<TKey, TValue>;
+
     public DictionaryAssert(IDictionary<TKey, TValue>? current) : base(current)
     { }
 
+    internal static bool IsSame<TLeft, TRight>(TLeft lKey, TRight rKey)
+    {
+        var left = lKey?.UnboxVariant() ?? null;
+        var right = rKey?.UnboxVariant() ?? null;
+
+        if ((left is string) || left?.GetType().IsPrimitive)
+            return Equals(left, right);
+        return ReferenceEquals(left, right);
+    }
+
+    public static DictionaryAssert<TKey, TValue> From(IDictionary? current)
+        => new(current);
+
+    private DictionaryAssert(IDictionary? current) : base(current)
+    { }
+
+    private int ItemCount => IsGeneric ? CurrentTyped?.Count ?? 0 : Current?.Count ?? 0;
+
+    private ICollection<TKey> Keys => (IsGeneric ? CurrentTyped?.Keys : Current?.Keys.Cast<TKey>().ToList()) ?? new List<TKey>();
+
+    private TValue? TryGetValue(TKey key)
+    {
+        if (Current != null)
+            return Current[key].Cast<TValue>();
+        return CurrentTyped?.ContainsKey(key) == true ? CurrentTyped[key] : default;
+    }
+
     public IDictionaryAssert<TKey, TValue> IsEmpty()
     {
-        if (Current == null || Current.Count != 0)
-            ThrowTestFailureReport(AssertFailures.IsEmpty(Current?.Count ?? 0, Current == null), Current, null);
+        if (Current == null && CurrentTyped == null)
+            ThrowTestFailureReport(AssertFailures.IsEmpty(ItemCount, true), ItemCount, null);
+        if (ItemCount != 0)
+            ThrowTestFailureReport(AssertFailures.IsEmpty(ItemCount, CurrentTyped == null && Current == null), ItemCount, null);
         return this;
+    }
+
+    public void CheckNotNull()
+    {
+        if (base.Current == null)
+            ThrowTestFailureReport(AssertFailures.IsNotNull(), base.Current, null);
     }
 
     public IDictionaryAssert<TKey, TValue> IsNotEmpty()
     {
-        IsNotNull();
-        if (Current?.Count == 0)
-            ThrowTestFailureReport(AssertFailures.IsNotEmpty(), Current, null);
+        CheckNotNull();
+        if (ItemCount == 0)
+            ThrowTestFailureReport(AssertFailures.IsNotEmpty(), base.Current, null);
         return this;
     }
 
     public IDictionaryAssert<TKey, TValue> HasSize(int expected)
     {
-        IsNotNull();
-        if (Current?.Count != expected)
-            ThrowTestFailureReport(AssertFailures.HasSize(Current!, expected), Current, expected);
+        CheckNotNull();
+        if (ItemCount != expected)
+            ThrowTestFailureReport(AssertFailures.HasSize(base.Current, expected), base.Current, expected);
         return this;
     }
 
     public IDictionaryAssert<TKey, TValue> ContainsKeys(params TKey[] expected)
     {
-        IsNotNull();
-        IEnumerable<TKey> keys = Current?.Keys.Cast<TKey>().ToList() ?? new List<TKey>();
-        var notFound = expected.Where(key => !keys.Contains(key)).ToList();
+        CheckNotNull();
+        var notFound = expected.Where(key => !Keys.Contains(key)).ToList();
 
         if (notFound.Count > 0)
-            ThrowTestFailureReport(AssertFailures.Contains(keys, expected!, notFound), Current, expected);
+            ThrowTestFailureReport(AssertFailures.Contains(Keys, expected!, notFound), base.Current, expected);
         return this;
     }
-    public IDictionaryAssert<TKey, TValue> ContainsKeys(IEnumerable expected) => ContainsKeys(expected.Cast<TKey>().ToArray());
+
+    public IDictionaryAssert<TKey, TValue> ContainsKeys(IEnumerable expected)
+        => ContainsKeys(expected.Cast<TKey>().ToArray());
 
     public IDictionaryAssert<TKey, TValue> NotContainsKeys(params TKey[] expected)
     {
-        IsNotNull();
-        IEnumerable<TKey> keys = Current?.Keys.Cast<TKey>().ToList() ?? new List<TKey>();
-        var found = expected.Where(key => keys.Contains(key)).ToList();
+        CheckNotNull();
+        var found = expected.Where(Keys.Contains).ToList();
         if (found.Count > 0)
-            ThrowTestFailureReport(AssertFailures.NotContains(keys, expected, found), Current, expected);
+            ThrowTestFailureReport(AssertFailures.NotContains(Keys, expected, found), base.Current, expected);
         return this;
     }
 
-    public IDictionaryAssert<TKey, TValue> NotContainsKeys(IEnumerable expected) => NotContainsKeys(expected.Cast<TKey>().ToArray());
+    public IDictionaryAssert<TKey, TValue> NotContainsKeys(IEnumerable expected)
+        => NotContainsKeys(expected.Cast<TKey>().ToArray());
 
     public IDictionaryAssert<TKey, TValue> ContainsKeyValue(TKey key, TValue value)
     {
-        IsNotNull();
-        var hasKey = Current!.ContainsKey(key);
+        CheckNotNull();
+        var hasKey = Keys.Contains(key);
         var expectedKeyValue = new Dictionary<TKey, TValue>() { { key, value } };
         if (!hasKey)
-            ThrowTestFailureReport(AssertFailures.ContainsKeyValue(expectedKeyValue), Current, expectedKeyValue);
+            ThrowTestFailureReport(AssertFailures.ContainsKeyValue(expectedKeyValue), base.Current, expectedKeyValue);
 
-        var currentValue = Current[key];
+        var currentValue = TryGetValue(key);
         var result = Comparable.IsEqual(currentValue, value);
         if (!result.Valid)
-            ThrowTestFailureReport(AssertFailures.ContainsKeyValue(expectedKeyValue, currentValue), Current, expectedKeyValue);
+            ThrowTestFailureReport(AssertFailures.ContainsKeyValue(expectedKeyValue, currentValue), base.Current, expectedKeyValue);
         return this;
     }
 
-    public new IDictionaryAssert<TKey, TValue> OverrideFailureMessage(string message)
+    public IDictionaryAssert<TKey, TValue> NotContainsSameKeys(params TKey[] expected)
     {
-        base.OverrideFailureMessage(message);
+        CheckNotNull();
+        var found = expected.Where(key => Enumerable.Any(Keys, (k) => IsSame(k, key))).ToList();
+        if (found.Count > 0)
+            ThrowTestFailureReport(AssertFailures.NotContains(Keys, expected, found), base.Current, expected);
         return this;
     }
+
+    public IDictionaryAssert<TKey, TValue> NotContainsSameKeys(IEnumerable expected)
+        => NotContainsSameKeys(expected.Cast<TKey>().ToArray());
+
+    public IDictionaryAssert<TKey, TValue> ContainsSameKeys(params TKey[] expected)
+    {
+        CheckNotNull();
+        var notFound = expected.Where(key => !Enumerable.Any(Keys, (k) => IsSame(k, key))).ToList();
+        if (notFound.Count > 0)
+            ThrowTestFailureReport(AssertFailures.Contains(Keys, expected!, notFound), base.Current, expected);
+        return this;
+    }
+
+    public IDictionaryAssert<TKey, TValue> ContainsSameKeys(IEnumerable expected)
+        => ContainsSameKeys(expected.Cast<TKey>().ToArray());
+
+    public IDictionaryAssert<TKey, TValue> ContainsSameKeyValue(TKey key, TValue value)
+    {
+        CheckNotNull();
+        var hasKey = Enumerable.Any(Keys, (k) => IsSame(k, key));
+        var expectedKeyValue = new Dictionary<TKey, TValue>() { { key, value } };
+        if (!hasKey)
+            ThrowTestFailureReport(AssertFailures.ContainsKeyValue(expectedKeyValue), base.Current, expectedKeyValue);
+
+        var currentValue = TryGetValue(key);
+        if (!IsSame(currentValue, value))
+            ThrowTestFailureReport(AssertFailures.ContainsKeyValue(expectedKeyValue, currentValue), base.Current, expectedKeyValue);
+        return this;
+    }
+
+    public IDictionaryAssert<TKey, TValue> IsSame(IEnumerable expected)
+    {
+        if (!ReferenceEquals(base.Current, expected))
+            ThrowTestFailureReport(AssertFailures.IsSame(base.Current, expected), base.Current, expected);
+        return this;
+    }
+
+    public IDictionaryAssert<TKey, TValue> IsSame(IDictionary<TKey, TValue> expected)
+    {
+        if (!ReferenceEquals(base.Current, expected))
+            ThrowTestFailureReport(AssertFailures.IsSame(base.Current, expected), base.Current, expected);
+        return this;
+    }
+
+    public IDictionaryAssert<TKey, TValue> IsNotSame(IEnumerable expected)
+    {
+        if (ReferenceEquals(base.Current, expected))
+            ThrowTestFailureReport(AssertFailures.IsSame(base.Current, expected), base.Current, expected);
+        return this;
+    }
+
+    public IDictionaryAssert<TKey, TValue> IsNotSame(IDictionary<TKey, TValue> expected)
+    {
+        if (ReferenceEquals(base.Current, expected))
+            ThrowTestFailureReport(AssertFailures.IsSame(base.Current, expected), base.Current, expected);
+        return this;
+    }
+
+
+    public new IDictionaryAssert<TKey, TValue> OverrideFailureMessage(string message)
+        => (IDictionaryAssert<TKey, TValue>)base.OverrideFailureMessage(message);
 }

--- a/api/src/asserts/EnumerableAssert.cs
+++ b/api/src/asserts/EnumerableAssert.cs
@@ -154,10 +154,7 @@ internal sealed class EnumerableAssert : AssertBase<IEnumerable>, IEnumerableAss
     }
 
     public new IEnumerableAssert OverrideFailureMessage(string message)
-    {
-        base.OverrideFailureMessage(message);
-        return this;
-    }
+        => (IEnumerableAssert)base.OverrideFailureMessage(message);
 
     private List<object?> ArrayContainsAll(IEnumerable<object?>? left, IEnumerable<object?>? right)
     {

--- a/api/src/asserts/ExceptionAssert.cs
+++ b/api/src/asserts/ExceptionAssert.cs
@@ -6,9 +6,9 @@ using System.Runtime.ExceptionServices;
 
 using Exceptions;
 
-internal sealed class ExceptionAssert<T> : IExceptionAssert
+internal sealed class ExceptionAssert<TException> : IExceptionAssert where TException : Exception
 {
-    private Exception? Current { get; set; }
+    private TException? Current { get; set; }
 
     private string? CustomFailureMessage { get; set; }
 
@@ -19,11 +19,11 @@ internal sealed class ExceptionAssert<T> : IExceptionAssert
         catch (Exception e)
         {
             var capturedException = ExceptionDispatchInfo.Capture(e.InnerException ?? e);
-            Current = capturedException.SourceException;
+            Current = (TException)capturedException.SourceException;
         }
     }
 
-    public ExceptionAssert(Exception e) => Current = e;
+    public ExceptionAssert(TException e) => Current = e;
 
     public IExceptionAssert IsInstanceOf<TExpectedType>()
     {

--- a/api/src/asserts/VectorAssert.cs
+++ b/api/src/asserts/VectorAssert.cs
@@ -2,68 +2,68 @@ namespace GdUnit4.Asserts;
 using System;
 using System.Globalization;
 
-internal class VectorAssert<T> : AssertBase<T>, IVectorAssert<T> where T : notnull, IEquatable<T>
+internal class VectorAssert<TValue> : AssertBase<TValue>, IVectorAssert<TValue> where TValue : notnull, IEquatable<TValue>
 {
 
-    public VectorAssert(T current) : base(current)
+    public VectorAssert(TValue current) : base(current)
     {
     }
 
-    public IVectorAssert<T> IsBetween(T min, T max)
+    public IVectorAssert<TValue> IsBetween(TValue min, TValue max)
     {
         if (CompareTo(Current, min) < 0 || CompareTo(Current, max) > 0)
             ThrowTestFailureReport(AssertFailures.IsBetween(Current, min, max), Current, min);
         return this;
     }
 
-    public new IVectorAssert<T> IsEqual(T expected) => (IVectorAssert<T>)base.IsEqual(expected);
+    public new IVectorAssert<TValue> IsEqual(TValue expected) => (IVectorAssert<TValue>)base.IsEqual(expected);
 
-    public IVectorAssert<T> IsEqualApprox(T expected, T approx)
+    public IVectorAssert<TValue> IsEqualApprox(TValue expected, TValue approx)
     {
         var minMax = MinMax(expected, approx);
         return IsBetween(minMax.Item1, minMax.Item2);
     }
 
-    public IVectorAssert<T> IsGreater(T expected)
+    public IVectorAssert<TValue> IsGreater(TValue expected)
     {
         if (CompareTo(Current, expected) <= 0)
             ThrowTestFailureReport(AssertFailures.IsGreater(Current!, expected), Current, expected);
         return this;
     }
 
-    public IVectorAssert<T> IsGreaterEqual(T expected)
+    public IVectorAssert<TValue> IsGreaterEqual(TValue expected)
     {
         if (CompareTo(Current, expected) < 0)
             ThrowTestFailureReport(AssertFailures.IsGreaterEqual(Current!, expected), Current, expected);
         return this;
     }
 
-    public IVectorAssert<T> IsLess(T expected)
+    public IVectorAssert<TValue> IsLess(TValue expected)
     {
         if (CompareTo(Current, expected) >= 0)
             ThrowTestFailureReport(AssertFailures.IsLess(Current!, expected), Current, expected);
         return this;
     }
 
-    public IVectorAssert<T> IsLessEqual(T expected)
+    public IVectorAssert<TValue> IsLessEqual(TValue expected)
     {
         if (CompareTo(Current, expected) > 0)
             ThrowTestFailureReport(AssertFailures.IsLessEqual(Current!, expected), Current, expected);
         return this;
     }
 
-    public IVectorAssert<T> IsNotBetween(T from, T to)
+    public IVectorAssert<TValue> IsNotBetween(TValue from, TValue to)
     {
         if (CompareTo(Current, from) >= 0 && CompareTo(Current, to) <= 0)
             ThrowTestFailureReport(AssertFailures.IsNotBetween(Current, from, to), Current, from);
         return this;
     }
 
-    public new IVectorAssert<T> IsNotEqual(T expected) => (IVectorAssert<T>)base.IsNotEqual(expected);
+    public new IVectorAssert<TValue> IsNotEqual(TValue expected) => (IVectorAssert<TValue>)base.IsNotEqual(expected);
 
-    public new IVectorAssert<T> OverrideFailureMessage(string message) => (IVectorAssert<T>)base.OverrideFailureMessage(message);
+    public new IVectorAssert<TValue> OverrideFailureMessage(string message) => (IVectorAssert<TValue>)base.OverrideFailureMessage(message);
 
-    private static int CompareTo(T? left, T right)
+    private static int CompareTo(TValue? left, TValue right)
     {
         if (left == null)
             return -1;
@@ -80,15 +80,15 @@ internal class VectorAssert<T> : AssertBase<T>, IVectorAssert<T> where T : notnu
     }
 
 #pragma warning disable CS8619
-    private static (T, T) MinMax(T left, T right) => (left, right) switch
+    private static (TValue, TValue) MinMax(TValue left, TValue right) => (left, right) switch
     {
-        (Godot.Vector2 l, Godot.Vector2 r) => ((T)Convert.ChangeType(l - r, typeof(T), CultureInfo.InvariantCulture), (T)Convert.ChangeType(l + r, typeof(T), CultureInfo.InvariantCulture)),
-        (Godot.Vector2I l, Godot.Vector2I r) => ((T)Convert.ChangeType(l - r, typeof(T), CultureInfo.InvariantCulture), (T)Convert.ChangeType(l + r, typeof(T), CultureInfo.InvariantCulture)),
-        (Godot.Vector3 l, Godot.Vector3 r) => ((T)Convert.ChangeType(l - r, typeof(T), CultureInfo.InvariantCulture), (T)Convert.ChangeType(l + r, typeof(T), CultureInfo.InvariantCulture)),
-        (Godot.Vector3I l, Godot.Vector3I r) => ((T)Convert.ChangeType(l - r, typeof(T), CultureInfo.InvariantCulture), (T)Convert.ChangeType(l + r, typeof(T), CultureInfo.InvariantCulture)),
-        (Godot.Vector4 l, Godot.Vector4 r) => ((T)Convert.ChangeType(l - r, typeof(T), CultureInfo.InvariantCulture), (T)Convert.ChangeType(l + r, typeof(T), CultureInfo.InvariantCulture)),
-        (Godot.Vector4I l, Godot.Vector4I r) => ((T)Convert.ChangeType(l - r, typeof(T), CultureInfo.InvariantCulture), (T)Convert.ChangeType(l + r, typeof(T), CultureInfo.InvariantCulture)),
-        _ => (default(T), default(T))
+        (Godot.Vector2 l, Godot.Vector2 r) => ((TValue)Convert.ChangeType(l - r, typeof(TValue), CultureInfo.InvariantCulture), (TValue)Convert.ChangeType(l + r, typeof(TValue), CultureInfo.InvariantCulture)),
+        (Godot.Vector2I l, Godot.Vector2I r) => ((TValue)Convert.ChangeType(l - r, typeof(TValue), CultureInfo.InvariantCulture), (TValue)Convert.ChangeType(l + r, typeof(TValue), CultureInfo.InvariantCulture)),
+        (Godot.Vector3 l, Godot.Vector3 r) => ((TValue)Convert.ChangeType(l - r, typeof(TValue), CultureInfo.InvariantCulture), (TValue)Convert.ChangeType(l + r, typeof(TValue), CultureInfo.InvariantCulture)),
+        (Godot.Vector3I l, Godot.Vector3I r) => ((TValue)Convert.ChangeType(l - r, typeof(TValue), CultureInfo.InvariantCulture), (TValue)Convert.ChangeType(l + r, typeof(TValue), CultureInfo.InvariantCulture)),
+        (Godot.Vector4 l, Godot.Vector4 r) => ((TValue)Convert.ChangeType(l - r, typeof(TValue), CultureInfo.InvariantCulture), (TValue)Convert.ChangeType(l + r, typeof(TValue), CultureInfo.InvariantCulture)),
+        (Godot.Vector4I l, Godot.Vector4I r) => ((TValue)Convert.ChangeType(l - r, typeof(TValue), CultureInfo.InvariantCulture), (TValue)Convert.ChangeType(l + r, typeof(TValue), CultureInfo.InvariantCulture)),
+        _ => (default(TValue), default(TValue))
     };
 #pragma warning restore CS8619
 

--- a/test/src/asserts/AssertionsTest.cs
+++ b/test/src/asserts/AssertionsTest.cs
@@ -97,4 +97,18 @@ public class AssertionsTest
         var obj = AutoFree((Node)null!);
         AssertThat(obj).IsNull();
     }
+
+    [TestCase]
+    public void AsObjectId()
+    {
+        var obj1 = new object();
+        var obj2 = new object();
+
+        AssertThat(AssertFailures.AsObjectId(obj1)).IsEqual($"<System.Object>(id: {obj1.GetHashCode()})");
+        AssertThat(AssertFailures.AsObjectId(obj1)).IsNotEqual(AssertFailures.AsObjectId(obj2));
+
+        var obj3 = new RefCounted();
+        AssertThat(AssertFailures.AsObjectId(obj3)).IsEqual($"<Godot.RefCounted>(id: {obj3.GetInstanceId()})");
+    }
+
 }

--- a/test/src/asserts/ObjectAssertTest.cs
+++ b/test/src/asserts/ObjectAssertTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Executions;
 using Exceptions;
 using static Assertions;
+using GdUnit4.Asserts;
 
 internal partial class CustomClass : Godot.RefCounted
 {
@@ -25,42 +26,61 @@ public class ObjectAssertTest
     [TestCase]
     public void IsEqual()
     {
-        var o = new object();
-        AssertObject(new Godot.BoxMesh()).IsEqual(new Godot.BoxMesh());
-        AssertObject(o).IsEqual(o);
+        var obj = new object();
+        var boxMesh = new Godot.BoxMesh();
+        var skin = new Godot.Skin();
+        AssertObject(boxMesh).IsEqual(boxMesh);
+        AssertObject(boxMesh).IsEqual(new Godot.BoxMesh());
+        AssertObject(obj).IsEqual(obj);
 
         // should fail because the current is an CubeMesh and we expect equal to a Skin
-        AssertThrown(() => AssertObject(new Godot.BoxMesh()).IsEqual(new Godot.Skin()))
+        AssertThrown(() => AssertObject(boxMesh).IsEqual(skin))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(33)
-            .HasMessage("Expecting be equal:\n"
-                + "    <Godot.Skin> but is <Godot.BoxMesh>");
-        AssertThrown(() => AssertObject(new object()).IsEqual(new List<int>()))
+            .HasFileLineNumber(37)
+            .HasMessage("""
+                Expecting be equal:
+                    $skin but is $boxMesh
+                """
+                    .Replace("$boxMesh", AssertFailures.AsObjectId(boxMesh))
+                    .Replace("$skin", AssertFailures.AsObjectId(skin)));
+        AssertThrown(() => AssertObject(obj).IsEqual(new List<int>()))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(38)
-            .HasMessage("Expecting be equal:\n"
-                + "    <Empty>\n"
-                + " but is\n"
-                + "    <System.Object>");
+            .HasFileLineNumber(46)
+            .HasMessage("""
+                Expecting be equal:
+                    <Empty>
+                 but is
+                    $obj
+                """
+                    .Replace("$obj", AssertFailures.AsObjectId(obj)));
     }
 
     [TestCase]
     public void IsNotEqual()
     {
-        var o = new object();
-        AssertObject(new Godot.BoxMesh()).IsNotEqual(new Godot.Skin());
-        AssertObject(o).IsNotEqual(new List<object>());
+        var obj = new object();
+        var boxMesh = new Godot.BoxMesh();
+        var skin = new Godot.Skin();
+        AssertObject(boxMesh).IsNotEqual(skin);
+        AssertObject(obj).IsNotEqual(new List<object>());
+
         // should fail because the current is an CubeMesh and we expect not equal to a CubeMesh
-        AssertThrown(() => AssertObject(new Godot.BoxMesh()).IsNotEqual(new Godot.BoxMesh()))
+        AssertThrown(() => AssertObject(boxMesh).IsNotEqual(boxMesh))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(54)
-            .HasMessage("Expecting be NOT equal:\n"
-                + "    <Godot.BoxMesh> but is <Godot.BoxMesh>");
-        AssertThrown(() => AssertObject(o).IsNotEqual(o))
+            .HasFileLineNumber(68)
+            .HasMessage("""
+                Expecting be NOT equal:
+                    $boxMesh but is $boxMesh
+                """
+                    .Replace("$boxMesh", AssertFailures.AsObjectId(boxMesh)));
+        AssertThrown(() => AssertObject(obj).IsNotEqual(obj))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(59)
-            .HasMessage("Expecting be NOT equal:\n"
-                + "    <System.Object> but is <System.Object>");
+            .HasFileLineNumber(76)
+            .HasMessage("""
+                Expecting be NOT equal:
+                    $obj but is $obj
+                """
+                    .Replace("$obj", AssertFailures.AsObjectId(obj)));
     }
 
     [TestCase]
@@ -83,17 +103,17 @@ public class ObjectAssertTest
         // should fail because the current is not a instance of `Tree`
         AssertThrown(() => AssertObject(AutoFree(new Godot.Path2D())).IsInstanceOf<Godot.Tree>())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(84)
+            .HasFileLineNumber(104)
             .HasMessage("Expected be instance of:\n"
                 + "    <Godot.Tree> but is <Godot.Path2D>");
         AssertThrown(() => AssertObject(null).IsInstanceOf<Godot.Tree>())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(89)
+            .HasFileLineNumber(109)
             .HasMessage("Expected be instance of:\n"
                 + "    <Godot.Tree> but is <Null>");
         AssertThrown(() => AssertObject(new CustomClass()).IsInstanceOf<CustomClassB>())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(94)
+            .HasFileLineNumber(114)
             .HasMessage("Expected be instance of:\n"
                 + "    <GdUnit4.Tests.Asserts.CustomClassB> but is <GdUnit4.Tests.Asserts.CustomClass>");
     }
@@ -113,12 +133,12 @@ public class ObjectAssertTest
         // should fail because the current is not a instance of `Tree`
         AssertThrown(() => AssertObject(AutoFree(new Godot.Path2D())).IsNotInstanceOf<Godot.Node>())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(114)
+            .HasFileLineNumber(134)
             .HasMessage("Expecting be NOT a instance of:\n"
                 + "    <Godot.Node>");
         AssertThrown(() => AssertObject(AutoFree(new CustomClassB())).IsNotInstanceOf<CustomClass>())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(119)
+            .HasFileLineNumber(139)
             .HasMessage("Expecting be NOT a instance of:\n"
                 + "    <GdUnit4.Tests.Asserts.CustomClass>");
     }
@@ -130,13 +150,13 @@ public class ObjectAssertTest
         // should fail because the current is not null
         AssertThrown(() => AssertObject(AutoFree(new Godot.Node())).IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(131)
+            .HasFileLineNumber(151)
             .StartsWithMessage("Expecting be <Null>:\n"
                 + " but is\n"
                 + "    <Godot.Node>");
         AssertThrown(() => AssertObject(new object()).IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(137)
+            .HasFileLineNumber(157)
             .StartsWithMessage("Expecting be <Null>:\n"
                 + " but is\n"
                 + "    <System.Object>");
@@ -150,7 +170,7 @@ public class ObjectAssertTest
         // should fail because the current is null
         AssertThrown(() => AssertObject(null).IsNotNull())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(151)
+            .HasFileLineNumber(171)
             .HasMessage("Expecting be NOT <Null>:");
     }
 
@@ -171,32 +191,47 @@ public class ObjectAssertTest
 
         AssertThrown(() => AssertObject(null).IsSame(obj1))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(172)
-            .HasMessage("Expecting be same:\n"
-                + "    <Godot.Node>\n"
-                + " to refer to the same object\n"
-                + "    <Null>");
+            .HasFileLineNumber(192)
+            .HasMessage("""
+                Expecting be same:
+                    $obj
+                 to refer to the same object
+                    <Null>
+                """
+                    .Replace("$obj", AssertFailures.AsObjectId(obj1)));
         AssertThrown(() => AssertObject(obj1).IsSame(obj3))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(179)
-            .HasMessage("Expecting be same:\n"
-                + "    <Godot.Node>\n"
-                + " to refer to the same object\n"
-                + "    <Godot.Node>");
+            .HasFileLineNumber(202)
+            .HasMessage("""
+                Expecting be same:
+                    $obj3
+                 to refer to the same object
+                    $obj1
+                """
+                    .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                    .Replace("$obj3", AssertFailures.AsObjectId(obj3)));
         AssertThrown(() => AssertObject(obj3).IsSame(obj1))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(186)
-            .HasMessage("Expecting be same:\n"
-                + "    <Godot.Node>\n"
-                + " to refer to the same object\n"
-                + "    <Godot.Node>");
+            .HasFileLineNumber(213)
+            .HasMessage("""
+                Expecting be same:
+                    $obj1
+                 to refer to the same object
+                    $obj3
+                """
+                    .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                    .Replace("$obj3", AssertFailures.AsObjectId(obj3)));
         AssertThrown(() => AssertObject(obj3).IsSame(obj2))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(193)
-            .HasMessage("Expecting be same:\n"
-                + "    <Godot.Node>\n"
-                + " to refer to the same object\n"
-                + "    <Godot.Node>");
+            .HasFileLineNumber(224)
+            .HasMessage("""
+                Expecting be same:
+                    $obj2
+                 to refer to the same object
+                    $obj3
+                """
+                    .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                    .Replace("$obj3", AssertFailures.AsObjectId(obj3)));
     }
 
     [TestCase]
@@ -218,16 +253,16 @@ public class ObjectAssertTest
 
         AssertThrown(() => AssertObject(obj1).IsNotSame(obj1))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(219)
-            .HasMessage("Expecting be NOT same: <Godot.Node>");
+            .HasFileLineNumber(254)
+            .HasMessage("Expecting be NOT same: $obj".Replace("$obj", AssertFailures.AsObjectId(obj1)));
         AssertThrown(() => AssertObject(obj1).IsNotSame(obj2))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(223)
-            .HasMessage("Expecting be NOT same: <Godot.Node>");
+            .HasFileLineNumber(258)
+            .HasMessage("Expecting be NOT same: $obj".Replace("$obj", AssertFailures.AsObjectId(obj2)));
         AssertThrown(() => AssertObject(obj2).IsNotSame(obj1))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(227)
-            .HasMessage("Expecting be NOT same: <Godot.Node>");
+            .HasFileLineNumber(262)
+            .HasMessage("Expecting be NOT same: $obj".Replace("$obj", AssertFailures.AsObjectId(obj1)));
     }
 
     [TestCase]
@@ -235,15 +270,15 @@ public class ObjectAssertTest
     {
         AssertThrown(() => AssertObject(1))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(236)
+            .HasFileLineNumber(271)
             .HasMessage("ObjectAssert initial error: current is primitive <System.Int32>");
         AssertThrown(() => AssertObject(1.3))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(240)
+            .HasFileLineNumber(275)
             .HasMessage("ObjectAssert initial error: current is primitive <System.Double>");
         AssertThrown(() => AssertObject(true))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(244)
+            .HasFileLineNumber(279)
             .HasMessage("ObjectAssert initial error: current is primitive <System.Boolean>");
     }
 
@@ -253,7 +288,7 @@ public class ObjectAssertTest
                 .OverrideFailureMessage("Custom failure message")
                 .IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(252)
+            .HasFileLineNumber(287)
             .HasMessage("Custom failure message");
 
     [TestCase]

--- a/test/src/asserts/SignalAssertTest.cs
+++ b/test/src/asserts/SignalAssertTest.cs
@@ -3,6 +3,8 @@ namespace GdUnit4.Tests.Asserts;
 
 using System.Threading.Tasks;
 
+using GdUnit4.Asserts;
+
 using static Assertions;
 
 
@@ -55,10 +57,11 @@ public partial class SignalAssertTest
                 .IsInstanceOf<Exceptions.TestFailedException>()
                 .HasMessage("""
                     Expecting do emitting signal:
-                        "SignalC(abc, 101)"
+                        "SignalC("abc", 101)"
                      by
-                        <GdUnit4.Tests.Asserts.SignalAssertTest+TestEmitter>
-                    """));
+                        $obj
+                    """
+                        .Replace("$obj", AssertFailures.AsObjectId(node))));
     }
 
     [TestCase]
@@ -77,8 +80,9 @@ public partial class SignalAssertTest
                     Expecting do NOT emitting signal:
                         "visibility_changed()"
                      by
-                        <Godot.Node2D>
-                    """));
+                        $obj
+                    """
+                        .Replace("$obj", AssertFailures.AsObjectId(node))));
     }
 
     [TestCase]
@@ -100,8 +104,9 @@ public partial class SignalAssertTest
                     Expecting do emitting signal:
                         "visibility_changed()"
                      by
-                        <Godot.Node2D>
-                    """));
+                        $obj
+                    """
+                        .Replace("$obj", AssertFailures.AsObjectId(node))));
 
         node.Show();
         await AssertSignal(node).IsEmitted("draw").WithTimeout(200);
@@ -125,7 +130,8 @@ public partial class SignalAssertTest
                 Expecting signal exists:
                     "not_existing_signal()"
                  on
-                    <Godot.Node2D>
-                """);
+                    $obj
+                """
+                    .Replace("$obj", AssertFailures.AsObjectId(node)));
     }
 }


### PR DESCRIPTION
# Why
The API differs between `GDScript` and C# and needs to be reconciled.

# What
- Fix Generic type namings
- Fix formatting issues on `AssertFailures` to handle Godot generic types and improve object instance rendering
- Fix invalid stack trace for unexpected exceptions
- `IDictionaryAssert` completely revised
  - fixes issues to handle generic dictionaries
  - ContainsSameKeyValue ✅
  - ContainsSameKeys ✅
  - NotContainsSameKeys ✅
  - IsNotSame ✅
  - IsSame ✅
