### PR TITLE
GD-10: Complete missing features for `IEnumerableAssert`

### DIFF
--- a/api/src/IDictionyryAssert.cs
+++ b/api/src/IDictionyryAssert.cs
@@ -65,7 +65,7 @@ public interface IDictionaryAssert<TKey, TValue> : IAssertBase<IEnumerable> wher
     /// Verifies that the current dictionary is the same.
     /// </summary>
     /// <remarks>
-    /// Compares the current by object reference equals.
+    /// Compares the current by object reference equals, for deep parameter comparison use <see cref="IAssertBase.IsEqual(TValue)"/>
     /// </remarks>
     /// <param name="expected"></param>
     public IDictionaryAssert<TKey, TValue> IsSame(IDictionary<TKey, TValue> expected);
@@ -75,7 +75,7 @@ public interface IDictionaryAssert<TKey, TValue> : IAssertBase<IEnumerable> wher
     /// Verifies that the current dictionary is NOT the same.
     /// </summary>
     /// <remarks>
-    /// Compares the current by object reference equals.
+    /// Compares the current by object reference equals, for deep parameter comparison use <see cref="IAssertBase.IsNotEqual(TValue)"/>
     /// </remarks>
     /// <param name="expected"></param>
     /// <returns></returns>

--- a/api/src/IEnumerableAssert.cs
+++ b/api/src/IEnumerableAssert.cs
@@ -1,54 +1,117 @@
 namespace GdUnit4.Asserts;
 
-using System.Collections;
+using System.Collections.Generic;
 
 /// <summary> An Assertion tool to verify enumerates </summary>
-public interface IEnumerableAssert : IAssertBase<IEnumerable>
+public interface IEnumerableAssert<TValue> : IAssertBase<IEnumerable<TValue?>>
 {
     /// <summary> Verifies that the current enumerable is equal to the given one, ignoring case considerations.</summary>
-    public IEnumerableAssert IsEqualIgnoringCase(IEnumerable expected);
+    public IEnumerableAssert<TValue?> IsEqualIgnoringCase(IEnumerable<TValue?> expected);
 
     /// <summary> Verifies that the current enumerable is not equal to the given one, ignoring case considerations.</summary>
-    public IEnumerableAssert IsNotEqualIgnoringCase(IEnumerable expected);
+    public IEnumerableAssert<TValue?> IsNotEqualIgnoringCase(IEnumerable<TValue?> expected);
 
     /// <summary> Verifies that the current enumerable is empty, it has a size of 0.</summary>
-    public IEnumerableAssert IsEmpty();
+    public IEnumerableAssert<TValue?> IsEmpty();
 
     /// <summary> Verifies that the current enumerable is not empty, it has a size of minimum 1.</summary>
-    public IEnumerableAssert IsNotEmpty();
+    public IEnumerableAssert<TValue?> IsNotEmpty();
+
+    /// <summary>
+    /// Verifies that the current enumerable is the same.
+    /// </summary>
+    /// <remarks>
+    /// Compares the current by object reference equals, for deep comparison use <see cref="IAssertBase.IsEqual(TValue)"/>
+    /// </remarks>
+    /// <param name="expected"></param>
+    public IEnumerableAssert<TValue?> IsSame(IEnumerable<TValue?> expected);
+
+    /// <summary>
+    /// Verifies that the current enumerable is not the same.
+    /// </summary>
+    /// <remarks>
+    /// Compares the current by object reference equals, for deep comparison use <see cref="IAssertBase.IsNotEqual(TValue)"/>
+    /// </remarks>
+    /// <param name="expected"></param>
+    public IEnumerableAssert<TValue?> IsNotSame(IEnumerable<TValue?> expected);
+
 
     /// <summary> Verifies that the current enumerable has a size of given value.</summary>
-    public IEnumerableAssert HasSize(int expected);
+    public IEnumerableAssert<TValue?> HasSize(int expected);
 
     /// <summary> Verifies that the current enumerable contains the given values, in any order.</summary>
-    public IEnumerableAssert Contains(IEnumerable expected);
+    public IEnumerableAssert<TValue?> Contains(params TValue?[] expected);
+    public IEnumerableAssert<TValue?> Contains(IEnumerable<TValue?> expected);
+    public IEnumerableAssert<TValue?> Contains(Godot.Collections.Array expected);
 
-    /// <summary> Verifies that the current enumerable contains the given values, in any order.</summary>
-    public IEnumerableAssert Contains(params object?[] expected);
+    /// <summary>
+    /// Verifies that the current enumerable contains the given values, in any order by object reference equals.
+    /// </summary>
+    /// <remarks>
+    /// Compares the current by object reference equals, for deep comparison use <see cref="Contains"/>
+    /// </remarks>
+    public IEnumerableAssert<TValue?> ContainsSame(params TValue?[] expected);
+    public IEnumerableAssert<TValue?> ContainsSame(IEnumerable<TValue?> expected);
+    public IEnumerableAssert<TValue?> ContainsSame(Godot.Collections.Array expected);
 
     /// <summary> Verifies that the current enumerable contains exactly only the given values and nothing else, in same order.</summary>
-    public IEnumerableAssert ContainsExactly(params object?[] expected);
+    public IEnumerableAssert<TValue?> ContainsExactly(params TValue?[] expected);
+    public IEnumerableAssert<TValue?> ContainsExactly(IEnumerable<TValue?> expected);
+    public IEnumerableAssert<TValue?> ContainsExactly(Godot.Collections.Array expected);
 
-    /// <summary> Verifies that the current enumerable contains exactly only the given values and nothing else, in same order.</summary>
-    public IEnumerableAssert ContainsExactly(IEnumerable expected);
+    /// <summary>
+    /// Verifies that the current enumerable contains exactly only the given values and nothing else, in same order by object reference equals.
+    /// </summary>
+    /// <remarks>
+    /// Compares the current by object reference equals, for deep comparison use <see cref="ContainsExactly"/>
+    /// </remarks>
+    public IEnumerableAssert<TValue?> ContainsSameExactly(params TValue?[] expected);
+    public IEnumerableAssert<TValue?> ContainsSameExactly(IEnumerable<TValue?> expected);
+    public IEnumerableAssert<TValue?> ContainsSameExactly(Godot.Collections.Array expected);
 
     /// <summary> Verifies that the current enumerable contains exactly only the given values and nothing else, in any order.</summary>
-    public IEnumerableAssert ContainsExactlyInAnyOrder(params object?[] expected);
+    public IEnumerableAssert<TValue?> ContainsExactlyInAnyOrder(params TValue?[] expected);
+    public IEnumerableAssert<TValue?> ContainsExactlyInAnyOrder(IEnumerable<TValue?> expected);
+    public IEnumerableAssert<TValue?> ContainsExactlyInAnyOrder(Godot.Collections.Array expected);
 
-    /// <summary> Verifies that the current enumerable contains exactly only the given values and nothing else, in any order.</summary>
-    public IEnumerableAssert ContainsExactlyInAnyOrder(IEnumerable expected);
+    /// <summary>
+    /// Verifies that the current enumerable contains exactly only the given values and nothing else, in any order by object reference equals.
+    /// </summary>
+    /// <remarks>
+    /// Compares the current by object reference equals, for deep comparison use <see cref="ContainsExactlyInAnyOrder"/>
+    /// </remarks>
+    public IEnumerableAssert<TValue?> ContainsSameExactlyInAnyOrder(params TValue?[] expected);
+    public IEnumerableAssert<TValue?> ContainsSameExactlyInAnyOrder(IEnumerable<TValue?> expected);
+    public IEnumerableAssert<TValue?> ContainsSameExactlyInAnyOrder(Godot.Collections.Array expected);
 
+    /// <summary>
+    /// Verifies that the current enumerable do NOT contains the given values, in any order.
+    /// </summary>
+    public IEnumerableAssert<TValue?> NotContains(params TValue?[] expected);
+    public IEnumerableAssert<TValue?> NotContains(IEnumerable<TValue?> expected);
+    public IEnumerableAssert<TValue?> NotContains(Godot.Collections.Array expected);
+
+
+    /// <summary>
+    /// Verifies that the current enumerable do NOT contains the given values, in any order by object reference equals.
+    /// </summary>
+    /// <remarks>
+    /// Compares the current by object reference equals, for deep comparison use <see cref="NotContains"/>
+    /// </remarks>
+    public IEnumerableAssert<TValue?> NotContainsSame(params TValue?[] expected);
+    public IEnumerableAssert<TValue?> NotContainsSame(IEnumerable<TValue?> expected);
+    public IEnumerableAssert<TValue?> NotContainsSame(Godot.Collections.Array expected);
     /// <summary>
     /// Extracts all values by given function name and optional arguments into a new EnumerableAssert<br />
     /// If the elements not accessible by `func_name` the value is converted to `"n.a"`, expecting null values
     /// </summary>
-    public IEnumerableAssert Extract(string funcName, params object[] args);
+    public IEnumerableAssert<object?> Extract(string funcName, params object[] args);
 
     /// <summary>
     /// Extracts all values by given extractor's into a new EnumerableAssert<br />
     /// If the elements not extractable than the value is converted to `"n.a"`, expecting null values
     /// </summary>
-    public IEnumerableAssert ExtractV(params IValueExtractor[] extractors);
+    public IEnumerableAssert<object?> ExtractV(params IValueExtractor[] extractors);
 
-    public new IEnumerableAssert OverrideFailureMessage(string message);
+    public new IEnumerableAssert<TValue?> OverrideFailureMessage(string message);
 }

--- a/api/src/asserts/AssertBase.cs
+++ b/api/src/asserts/AssertBase.cs
@@ -57,4 +57,14 @@ internal abstract class AssertBase<TValue> : IAssertBase<TValue>
         CurrentFailureMessage = failureMessage;
         throw new TestFailedException(failureMessage);
     }
+
+    protected static bool IsSame<TLeft, TRight>(TLeft lKey, TRight rKey)
+    {
+        var left = lKey.UnboxVariant();
+        var right = rKey.UnboxVariant();
+
+        if (((left is string) || left?.GetType().IsPrimitive) ?? false)
+            return Equals(left, right);
+        return ReferenceEquals(left, right);
+    }
 }

--- a/api/src/asserts/DictionaryAssert.cs
+++ b/api/src/asserts/DictionaryAssert.cs
@@ -19,16 +19,6 @@ internal sealed class DictionaryAssert<TKey, TValue> : AssertBase<IEnumerable>, 
     public DictionaryAssert(IDictionary<TKey, TValue>? current) : base(current)
     { }
 
-    internal static bool IsSame<TLeft, TRight>(TLeft lKey, TRight rKey)
-    {
-        var left = lKey?.UnboxVariant() ?? null;
-        var right = rKey?.UnboxVariant() ?? null;
-
-        if ((left is string) || left?.GetType().IsPrimitive)
-            return Equals(left, right);
-        return ReferenceEquals(left, right);
-    }
-
     public static DictionaryAssert<TKey, TValue> From(IDictionary? current)
         => new(current);
 

--- a/api/src/asserts/EnumerableAssert.cs
+++ b/api/src/asserts/EnumerableAssert.cs
@@ -1,18 +1,20 @@
 namespace GdUnit4.Asserts;
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-using static GdUnit4.Assertions;
-
-
-internal sealed class EnumerableAssert : AssertBase<IEnumerable>, IEnumerableAssert
+internal sealed class EnumerableAssert<TValue> : AssertBase<IEnumerable<TValue?>>, IEnumerableAssert<TValue?>
 {
-    public EnumerableAssert(IEnumerable? current) : base(current) => Current = current?.Cast<object?>();
 
-    private new IEnumerable<object?>? Current { get; set; }
+    public EnumerableAssert(IEnumerable? current) : base(current?.Cast<TValue?>())
+    { }
 
-    public IEnumerableAssert IsEqualIgnoringCase(IEnumerable expected)
+    public EnumerableAssert(IEnumerable<TValue?>? current) : base(current)
+    { }
+
+    public IEnumerableAssert<TValue?> IsEqualIgnoringCase(IEnumerable<TValue?> expected)
     {
         var result = Comparable.IsEqual(Current, expected, GodotObjectExtensions.MODE.CaseInsensitive);
         if (!result.Valid)
@@ -20,7 +22,7 @@ internal sealed class EnumerableAssert : AssertBase<IEnumerable>, IEnumerableAss
         return this;
     }
 
-    public IEnumerableAssert IsNotEqualIgnoringCase(IEnumerable expected)
+    public IEnumerableAssert<TValue?> IsNotEqualIgnoringCase(IEnumerable<TValue?> expected)
     {
         var result = Comparable.IsEqual(Current, expected, GodotObjectExtensions.MODE.CaseInsensitive);
         if (result.Valid)
@@ -28,7 +30,7 @@ internal sealed class EnumerableAssert : AssertBase<IEnumerable>, IEnumerableAss
         return this;
     }
 
-    public IEnumerableAssert IsEmpty()
+    public IEnumerableAssert<TValue?> IsEmpty()
     {
         var count = Current?.Count() ?? -1;
         if (count != 0)
@@ -36,7 +38,7 @@ internal sealed class EnumerableAssert : AssertBase<IEnumerable>, IEnumerableAss
         return this;
     }
 
-    public IEnumerableAssert IsNotEmpty()
+    public IEnumerableAssert<TValue?> IsNotEmpty()
     {
         var count = Current?.Count() ?? -1;
         if (count == 0)
@@ -44,7 +46,21 @@ internal sealed class EnumerableAssert : AssertBase<IEnumerable>, IEnumerableAss
         return this;
     }
 
-    public IEnumerableAssert HasSize(int expected)
+    public IEnumerableAssert<TValue?> IsSame(IEnumerable<TValue?> expected)
+    {
+        if (!ReferenceEquals(Current, expected))
+            ThrowTestFailureReport(AssertFailures.IsSame(Current, expected), Current, expected);
+        return this;
+    }
+
+    public IEnumerableAssert<TValue?> IsNotSame(IEnumerable<TValue?> expected)
+    {
+        if (ReferenceEquals(Current, expected))
+            ThrowTestFailureReport(AssertFailures.IsNotSame(expected), Current, expected);
+        return this;
+    }
+
+    public IEnumerableAssert<TValue?> HasSize(int expected)
     {
         var count = Current?.Count();
         if (count != expected)
@@ -52,153 +68,241 @@ internal sealed class EnumerableAssert : AssertBase<IEnumerable>, IEnumerableAss
         return this;
     }
 
-    public IEnumerableAssert Contains(params object?[] expected)
+    public IEnumerableAssert<TValue?> Contains(params TValue?[] expected)
+        => CheckContains(expected.ToList(), false);
+
+    public IEnumerableAssert<TValue?> Contains(IEnumerable<TValue?> expected)
+        => CheckContains(expected, false);
+    public IEnumerableAssert<TValue?> Contains(Godot.Collections.Array expected)
+    {
+        var expected_ = expected as IEnumerable<TValue?>;
+        return CheckContains(expected_!, false);
+    }
+
+    public IEnumerableAssert<TValue?> ContainsSame(params TValue?[] expected)
+          => CheckContains(expected.ToList(), true);
+
+    public IEnumerableAssert<TValue?> ContainsSame(IEnumerable<TValue?> expected)
+        => CheckContains(expected, true);
+
+    public IEnumerableAssert<TValue?> ContainsSame(Godot.Collections.Array expected)
+    {
+        var expected_ = expected as IEnumerable<TValue?>;
+        return CheckContains(expected_!, true);
+    }
+
+    public IEnumerableAssert<TValue?> ContainsExactly(params TValue?[] expected)
+        => CheckContainsExactly(expected.ToList(), false);
+
+    public IEnumerableAssert<TValue?> ContainsExactly(IEnumerable<TValue?> expected)
+        => CheckContainsExactly(expected, false);
+
+    public IEnumerableAssert<TValue?> ContainsExactly(Godot.Collections.Array expected)
+    {
+        var expected_ = expected as IEnumerable<TValue?>;
+        return CheckContainsExactly(expected_!, false);
+    }
+
+    public IEnumerableAssert<TValue?> ContainsSameExactly(params TValue?[] expected)
+        => CheckContainsExactly(expected.ToList(), true);
+
+    public IEnumerableAssert<TValue?> ContainsSameExactly(IEnumerable<TValue?> expected)
+        => CheckContainsExactly(expected, true);
+
+    public IEnumerableAssert<TValue?> ContainsSameExactly(Godot.Collections.Array expected)
+    {
+        var expected_ = expected as IEnumerable<TValue?>;
+        return CheckContainsExactly(expected_!, true);
+    }
+
+    public IEnumerableAssert<TValue?> ContainsExactlyInAnyOrder(params TValue?[] expected)
+        => CheckContainsExactlyInAnyOrder(expected.ToList(), false);
+
+    public IEnumerableAssert<TValue?> ContainsExactlyInAnyOrder(IEnumerable<TValue?> expected)
+        => CheckContainsExactlyInAnyOrder(expected, false);
+
+    public IEnumerableAssert<TValue?> ContainsExactlyInAnyOrder(Godot.Collections.Array expected)
+    {
+        var expected_ = expected as IEnumerable<TValue?>;
+        return CheckContainsExactlyInAnyOrder(expected_!, false);
+    }
+
+    public IEnumerableAssert<TValue?> ContainsSameExactlyInAnyOrder(params TValue?[] expected)
+        => CheckContainsExactlyInAnyOrder(expected.ToList(), true);
+
+    public IEnumerableAssert<TValue?> ContainsSameExactlyInAnyOrder(IEnumerable<TValue?> expected)
+        => CheckContainsExactlyInAnyOrder(expected, true);
+
+    public IEnumerableAssert<TValue?> ContainsSameExactlyInAnyOrder(Godot.Collections.Array expected)
+    {
+        var expected_ = expected as IEnumerable<TValue?>;
+        return CheckContainsExactlyInAnyOrder(expected_!, true);
+    }
+
+    public IEnumerableAssert<TValue?> NotContains(params TValue?[] expected)
+        => CheckNotContains(expected.ToList(), false);
+
+    public IEnumerableAssert<TValue?> NotContains(IEnumerable<TValue?> expected)
+        => CheckNotContains(expected, false);
+
+    public IEnumerableAssert<TValue?> NotContains(Godot.Collections.Array expected)
+    {
+        var expected_ = expected as IEnumerable<TValue?>;
+        return CheckNotContains(expected_!, false);
+    }
+
+    public IEnumerableAssert<TValue?> NotContainsSame(params TValue?[] expected)
+        => CheckNotContains(expected.ToList(), true);
+
+    public IEnumerableAssert<TValue?> NotContainsSame(IEnumerable<TValue?> expected)
+         => CheckNotContains(expected, true);
+
+    public IEnumerableAssert<TValue?> NotContainsSame(Godot.Collections.Array expected)
+    {
+        var expected_ = expected as IEnumerable<TValue?>;
+        return CheckNotContains(expected_!, true);
+    }
+
+    public IEnumerableAssert<object?> Extract(string funcName, params object[] args)
+        => ExtractV(new ValueExtractor(funcName, args));
+
+    public IEnumerableAssert<object?> ExtractV(params IValueExtractor[] extractors)
+        => new EnumerableAssert<object?>(Current?.Select(v =>
+        {
+            var values = extractors.Select(e => e.ExtractValue(v)).ToArray();
+            return values.Length == 1 ? values.First() : new Tuple(values);
+        })
+        .ToList());
+
+    public new IEnumerableAssert<TValue?> OverrideFailureMessage(string message)
+        => (IEnumerableAssert<TValue?>)base.OverrideFailureMessage(message);
+
+    private EnumerableAssert<TValue?> CheckContains(IEnumerable<TValue?> expected, bool referenceEquals)
     {
         // we test for contains nothing
-        if (expected.Length == 0)
+        if (!expected.Any())
             return this;
-        var notFound = ArrayContainsAll(Current, expected);
+
+        var notFound = expected
+                    .ToList()
+                    .FindAll(left => !Current?.Any(e => (referenceEquals ? IsSame(left) : IsEquals(left)).Invoke(e)) ?? true);
         if (notFound.Count > 0)
             ThrowTestFailureReport(AssertFailures.Contains(Current, expected, notFound), Current, expected);
         return this;
     }
 
-    public IEnumerableAssert Contains(IEnumerable expected)
-    {
-        var expectedArray = expected.Cast<object>().ToArray();
-        // we test for contains nothing
-        if (expectedArray.Length == 0)
-            return this;
-
-        var notFound = ArrayContainsAll(Current, expectedArray);
-        if (notFound.Count > 0)
-            ThrowTestFailureReport(AssertFailures.Contains(Current, expectedArray, notFound), Current, expected);
-        return this;
-    }
-
-    public IEnumerableAssert ContainsExactly(params object?[] expected)
+    private EnumerableAssert<TValue?> CheckContainsExactly(IEnumerable<TValue?> expected, bool referenceEquals)
     {
         // we test for contains nothing
-        if (expected.Length == 0)
+        if (!expected.Any())
             return this;
-        // is equal than it contains same elements in same order
-        if (Comparable.IsEqual(Current, expected).Valid)
-            return this;
-        var diff = DiffArray(Current, expected);
+
+        var diff = DiffArrayExactly(Current, expected, referenceEquals);
         var notExpected = diff.NotExpected;
         var notFound = diff.NotFound;
-        if (notFound.Count > 0 || notExpected.Count > 0 || (notFound.Count == 0 && notExpected.Count == 0))
+        if (notExpected.Count != 0 || notFound.Count != 0)
             ThrowTestFailureReport(AssertFailures.ContainsExactly(Current, expected, notFound, notExpected), Current, expected);
         return this;
     }
 
-    public IEnumerableAssert ContainsExactly(IEnumerable expected)
-    {
-        var expectedArray = expected is string ? new object?[] { expected } : expected.Cast<object?>().ToArray();
-        // we test for contains nothing
-        if (expectedArray.Length == 0)
-            return this;
-        // is equal than it contains same elements in same order
-        if (Comparable.IsEqual(Current, expectedArray).Valid)
-            return this;
-
-        var diff = DiffArray(Current, expectedArray);
-        var notExpected = diff.NotExpected;
-        var notFound = diff.NotFound;
-        if (notFound.Count > 0 || notExpected.Count > 0 || (notFound.Count == 0 && notExpected.Count == 0))
-            ThrowTestFailureReport(AssertFailures.ContainsExactly(Current, expectedArray, notFound, notExpected), Current, expected);
-        return this;
-    }
-
-    public IEnumerableAssert ContainsExactlyInAnyOrder(params object?[] expected)
+    private EnumerableAssert<TValue?> CheckContainsExactlyInAnyOrder(IEnumerable<TValue?> expected, bool referenceEquals)
     {
         // we test for contains nothing
-        if (expected.Length == 0)
+        if (!expected.Any())
             return this;
-        var diff = DiffArray(Current, expected);
+
+        var diff = DiffArrayAnyOrder(Current, expected, referenceEquals);
         var notExpected = diff.NotExpected;
         var notFound = diff.NotFound;
-
         // no difference and additions found
         if (notExpected.Count != 0 || notFound.Count != 0)
             ThrowTestFailureReport(AssertFailures.ContainsExactlyInAnyOrder(Current, expected, notFound, notExpected), Current, expected);
         return this;
     }
 
-    public IEnumerableAssert ContainsExactlyInAnyOrder(IEnumerable expected)
+    private EnumerableAssert<TValue?> CheckNotContains(IEnumerable<TValue?> expected, bool referenceEquals)
     {
-        var expectedArray = expected.Cast<object?>().ToArray();
-        // we test for contains nothing
-        if (expectedArray.Length == 0)
+        if (!expected.Any())
             return this;
 
-        var diff = DiffArray(Current, expectedArray);
-        var notExpected = diff.NotExpected;
-        var notFound = diff.NotFound;
-        // no difference and additions found
-        if (notExpected.Count != 0 || notFound.Count != 0)
-            ThrowTestFailureReport(AssertFailures.ContainsExactlyInAnyOrder(Current, expectedArray, notFound, notExpected), Current, expected);
+        var found = Current?
+                .ToList()
+                .FindAll(left => expected?.Any(e => (referenceEquals ? IsSame(left) : IsEquals(left)).Invoke(e)) ?? false)
+            ?? new List<TValue?>();
+        if (found.Count != 0)
+            ThrowTestFailureReport(AssertFailures.NotContains(Current, expected, found), Current, expected);
         return this;
-    }
-
-    public IEnumerableAssert Extract(string funcName, params object[] args) => ExtractV(new ValueExtractor(funcName, args));
-
-    public IEnumerableAssert ExtractV(params IValueExtractor[] extractors)
-    {
-        Current = Current?.Select(v =>
-        {
-            var values = extractors.Select(e => e.ExtractValue(v)).ToArray();
-            return values.Length == 1 ? values.First() : Tuple(values);
-        }).ToList();
-        return this;
-    }
-
-    public new IEnumerableAssert OverrideFailureMessage(string message)
-        => (IEnumerableAssert)base.OverrideFailureMessage(message);
-
-    private List<object?> ArrayContainsAll(IEnumerable<object?>? left, IEnumerable<object?>? right)
-    {
-        var notFound = right?.ToList() ?? new List<object?>();
-
-        if (left != null)
-        {
-            var leftList = left.ToList();
-            foreach (var c in leftList)
-            {
-                var found = right?.FirstOrDefault(e => Comparable.IsEqual(c, e).Valid);
-                if (found != null)
-                    notFound.Remove(found);
-            }
-        }
-        return notFound;
     }
 
     private class ArrayDiff
     {
-        public List<object?> NotExpected { get; set; } = new List<object?>();
-        public List<object?> NotFound { get; set; } = new List<object?>();
+        public List<TValue?> NotExpected { get; set; } = new List<TValue?>();
+        public List<TValue?> NotFound { get; set; } = new List<TValue?>();
     }
 
-    private ArrayDiff DiffArray(IEnumerable<object?>? left, IEnumerable<object?>? right)
+    private ArrayDiff DiffArrayAnyOrder(
+        IEnumerable<TValue?>? current,
+        IEnumerable<TValue?>? expected,
+        bool referenceEquals = false)
     {
-        var ll = left?.ToList() ?? new List<object?>();
-        var rr = right?.ToList() ?? new List<object?>();
+        var ll = current?.ToArray() ?? Array.Empty<TValue?>();
+        var rr = expected?.ToArray() ?? Array.Empty<TValue?>();
 
-        var notExpected = left?.ToList() ?? new List<object?>();
-        var notFound = right?.ToList() ?? new List<object?>();
+        var notExpected = new List<TValue?>();
+        var notFound = new List<TValue?>();
 
-        foreach (var c in ll)
+        for (var i = 0; i < ll.Length; i++)
         {
-            foreach (var e in rr)
-            {
-                if (Comparable.IsEqual(c, e).Valid)
-                {
-                    notExpected.Remove(c);
-                    notFound.Remove(e);
-                    break;
-                }
-            }
+            var left = ll[i];
+            if (!rr.Any(e => (referenceEquals ? IsSame(left) : IsEquals(left)).Invoke(e)))
+                notExpected.Add(left);
         }
-        return new ArrayDiff() { NotExpected = notExpected, NotFound = notFound };
+        for (var i = 0; i < rr.Length; i++)
+        {
+            var right = rr[i];
+            if (!ll.Any(e => (referenceEquals ? IsSame(right) : IsEquals(right)).Invoke(e)))
+                notFound.Add(right);
+        }
+
+        return new ArrayDiff()
+        {
+            NotExpected = notExpected,
+            NotFound = notFound
+        };
     }
+
+    private ArrayDiff DiffArrayExactly(
+        IEnumerable<TValue?>? current,
+        IEnumerable<TValue?>? expected,
+        bool referenceEquals = false)
+    {
+        var ll = current?.ToArray() ?? Array.Empty<TValue?>();
+        var rr = expected?.ToArray() ?? Array.Empty<TValue?>();
+
+        var notExpected = new List<TValue?>();
+        var notFound = new List<TValue?>();
+
+        for (var i = 0; i < ll.Length; i++)
+        {
+            var left = ll[i];
+            if (i >= rr.Length || !(referenceEquals ? IsSame(left) : IsEquals(left)).Invoke(rr[i]))
+                notExpected.Add(left);
+        }
+        for (var i = 0; i < rr.Length; i++)
+        {
+            var right = rr[i];
+            if (i >= ll.Length || !(referenceEquals ? IsSame(right) : IsEquals(right)).Invoke(ll[i]))
+                notFound.Add(right);
+        }
+        return new ArrayDiff()
+        {
+            NotExpected = notExpected,
+            NotFound = notFound,
+        };
+    }
+
+    private static Func<TValue?, bool> IsEquals(TValue? c) => e => c.UnboxVariant() == e.UnboxVariant();
+
+    private static Func<TValue?, bool> IsSame(TValue? c) => e => AssertBase<TValue>.IsSame(c, e);
+
 }

--- a/api/src/core/execution/TestCase.cs
+++ b/api/src/core/execution/TestCase.cs
@@ -60,12 +60,16 @@ internal sealed class TestCase
     public object[] Arguments => Parameters.SelectMany(ResolveParam).ToArray();
 
     public static string BuildTestCaseName(string testName, TestCaseAttribute attribute)
+        => BuildTestCaseName(testName, attribute.TestName ?? testName, attribute.Arguments);
+
+    public static string BuildTestCaseName(string testName, string parameterizedName, params object?[] arguments)
     {
-        if (attribute.Arguments.Length > 0)
+        if (arguments.Length > 0)
         {
             var saveCulture = Thread.CurrentThread.CurrentCulture;
             Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US", true);
-            testName = $"{testName}.{attribute.TestName ?? testName}({attribute.Arguments.Formatted()})";
+            var parameters = string.Join(", ", arguments.ToArray().Select(GdUnitExtensions.Formatted));
+            testName = $"{testName}.{parameterizedName}({parameters})";
             Thread.CurrentThread.CurrentCulture = saveCulture;
         }
         return testName;

--- a/api/src/core/execution/TestSuite.cs
+++ b/api/src/core/execution/TestSuite.cs
@@ -70,7 +70,7 @@ internal sealed class TestSuite : IDisposable
             var testCases = mi.GetCustomAttributes(typeof(TestCaseAttribute))
                 .Cast<TestCaseAttribute>()
                 .Where(attr => attr != null && attr.Arguments?.Length != 0)
-                .Select(attr => primitiveFilter ? mi.Name : $"{attr.TestName ?? mi.Name}({attr.Arguments.Formatted()})")
+                .Select(attr => primitiveFilter ? mi.Name : TestCase.BuildTestCaseName(mi.Name, attr))
                 .DefaultIfEmpty($"{mi.Name}")
                 .ToList();
             Thread.CurrentThread.CurrentCulture = saveCulture;

--- a/api/src/core/exensions/GdUnitExtensions.cs
+++ b/api/src/core/exensions/GdUnitExtensions.cs
@@ -35,10 +35,10 @@ public static partial class GdUnitExtensions
 
     internal static string Formatted(this object? value)
     {
-        if (value == null)
-            return "<Null>";
         if (value is Godot.Variant v)
             value = v.UnboxVariant();
+        if (value == null)
+            return "<Null>";
         if (value is string asString)
             return asString.Formatted();
         return value switch
@@ -49,12 +49,24 @@ public static partial class GdUnitExtensions
         };
     }
 
-    internal static string Formatted(this Asserts.Tuple? value) => value?.ToString() ?? "<Null>";
-    internal static string Formatted(this string? value) => $"\"{value?.ToString()}\"" ?? "<Null>";
-    internal static string Formatted(this Godot.Variant[] args, int indentation = 0) => string.Join(", ", args.Cast<Godot.Variant>().Select(v => v.Formatted())).Indentation(indentation);
-    internal static string Formatted(this Godot.Collections.Array args, int indentation = 0) => args.UnboxVariant()?.Formatted(indentation) ?? "<empty>";
-    internal static string Formatted(this object?[] args, int indentation = 0) => string.Join(", ", args.ToArray().Select(Formatted)).Indentation(indentation);
-    internal static string Formatted(this IEnumerable args, int indentation = 0) => string.Join(", ", args.Cast<object>().Select(Formatted)).Indentation(indentation);
+    internal static string Formatted(this Godot.Variant value)
+        => Formatted(value as object);
+    internal static string Formatted(this Asserts.Tuple? value)
+        => value?.ToString() ?? "<Null>";
+    internal static string Formatted(this string? value)
+        => $"\"{value?.ToString()}\"" ?? "<Null>";
+
+    internal static string Formatted(this Godot.Collections.Array args, int indentation = 0)
+        => args.ToArray().Formatted(indentation);
+    internal static string Formatted<[Godot.MustBeVariant] TValue>(this Godot.Collections.Array<TValue> args, int indentation = 0)
+        => args.ToArray().Formatted(indentation);
+    internal static string Formatted<TValue>(this TValue?[] args, int indentation = 0)
+        => args.Length == 0
+            ? "<Empty>"
+            : "[" + string.Join(", ", args.ToArray().Select(v => Formatted(v))).Indentation(indentation) + "]";
+    internal static string Formatted(this IEnumerable args, int indentation = 0)
+        => Formatted(args.Cast<object?>().ToArray(), indentation);
+
     internal static string UnixFormat(this string value) => value.Replace("\r", string.Empty);
 
     internal static string Indentation(this string value, int indentation)

--- a/api/src/extractors/Tuple.cs
+++ b/api/src/extractors/Tuple.cs
@@ -17,5 +17,17 @@ internal sealed class Tuple : ITuple
 
     public override int GetHashCode() => HashCode.Combine(Values);
 
-    public override string ToString() => $"tuple({Values.Formatted()})";
+    public override string ToString()
+        => $"tuple({string.Join(", ", Values.Cast<object>().Select(GdUnitExtensions.Formatted)).Indentation(0)})";
+
+    public static bool operator ==(Tuple? tuple1, Tuple? tuple2)
+    {
+        if (ReferenceEquals(tuple1, tuple2))
+            return true;
+        if (tuple1 is null || tuple2 is null)
+            return false;
+        return tuple1.Values.VariantEquals(tuple2.Values);
+    }
+
+    public static bool operator !=(Tuple? tuple1, Tuple? tuple2) => !(tuple1 == tuple2);
 }

--- a/test/src/asserts/AssertionsTest.cs
+++ b/test/src/asserts/AssertionsTest.cs
@@ -73,12 +73,13 @@ public class AssertionsTest
     [TestCase]
     public void AssertThatEnumerable()
     {
-        AssertObject(AssertThat(System.Array.Empty<byte>())).IsInstanceOf<IEnumerableAssert>();
-        AssertObject(AssertThat(new System.Collections.ArrayList())).IsInstanceOf<IEnumerableAssert>();
-        AssertObject(AssertThat(new System.Collections.BitArray(new bool[] { true, false }))).IsInstanceOf<IEnumerableAssert>();
-        AssertObject(AssertThat(new System.Collections.Generic.HashSet<byte>())).IsInstanceOf<IEnumerableAssert>();
-        AssertObject(AssertThat(new System.Collections.Generic.List<byte>())).IsInstanceOf<IEnumerableAssert>();
-        AssertObject(AssertThat(new Godot.Collections.Array())).IsInstanceOf<IEnumerableAssert>();
+        AssertObject(AssertThat(System.Array.Empty<byte>())).IsInstanceOf<IEnumerableAssert<byte>>();
+        AssertObject(AssertThat(new System.Collections.ArrayList())).IsInstanceOf<IEnumerableAssert<object>>();
+        AssertObject(AssertThat(new System.Collections.BitArray(new bool[] { true, false }))).IsInstanceOf<IEnumerableAssert<bool>>();
+        AssertObject(AssertThat(new System.Collections.Generic.HashSet<byte>())).IsInstanceOf<IEnumerableAssert<byte>>();
+        AssertObject(AssertThat(new System.Collections.Generic.List<byte>())).IsInstanceOf<IEnumerableAssert<byte>>();
+        AssertObject(AssertThat(new Godot.Collections.Array())).IsInstanceOf<IEnumerableAssert<Variant>>();
+        AssertObject(AssertThat(new Godot.Collections.Array<int>())).IsInstanceOf<IEnumerableAssert<int>>();
     }
 
     [TestCase]
@@ -104,11 +105,22 @@ public class AssertionsTest
         var obj1 = new object();
         var obj2 = new object();
 
+        AssertThat(AssertFailures.AsObjectId(null)).IsEqual($"<Null>");
         AssertThat(AssertFailures.AsObjectId(obj1)).IsEqual($"<System.Object>(id: {obj1.GetHashCode()})");
         AssertThat(AssertFailures.AsObjectId(obj1)).IsNotEqual(AssertFailures.AsObjectId(obj2));
 
+        // on Godot Objects
         var obj3 = new RefCounted();
         AssertThat(AssertFailures.AsObjectId(obj3)).IsEqual($"<Godot.RefCounted>(id: {obj3.GetInstanceId()})");
+        var obj4 = new QuadMesh();
+        AssertThat(AssertFailures.AsObjectId(obj4)).IsEqual($"<Godot.QuadMesh>(id: {obj4.GetInstanceId()})");
+
+        // on Godot Variants
+        var obj5 = new RefCounted();
+        AssertThat(AssertFailures.AsObjectId(obj5.ToVariant())).IsEqual($"<Godot.RefCounted>(id: {obj5.GetInstanceId()})");
+
+        object? obj6 = null;
+        AssertThat(AssertFailures.AsObjectId(obj6.ToVariant())).IsEqual($"<Godot.Variant>(Null)");
     }
 
 }

--- a/test/src/asserts/EnumerableAssertTest.cs
+++ b/test/src/asserts/EnumerableAssertTest.cs
@@ -1,42 +1,31 @@
 namespace GdUnit4.Tests.Asserts;
 
 using System;
+using System.Collections.Generic;
 
 using Godot;
-using static Assertions;
 using Executions;
 using Exceptions;
 
+using static Assertions;
+using GdUnit4.Asserts;
 
 [TestSuite]
 public partial class EnumerableAssertTest
 {
-    [TestCase]
-    public void IsNull()
+    [TestCase(0, TestName = "Array")]
+    [TestCase(1, TestName = "List")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void IsNull(int dataIndex)
     {
+        dynamic current = TestDataPointEmptyArrays[dataIndex];
         AssertArray(null).IsNull();
 
         // should fail because the current is not null
-        AssertThrown(() => AssertArray(Array.Empty<object>()).IsNull())
+        AssertThrown(() => AssertArray(current).IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(20)
-            .HasMessage("""
-                    Expecting be <Null>:
-                     but is
-                        <Empty>
-                    """);
-        AssertThrown(() => AssertArray(Array.Empty<int>()).IsNull())
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(28)
-            .HasMessage("""
-                    Expecting be <Null>:
-                     but is
-                        <Empty>
-                    """);
-        // with godot array
-        AssertThrown(() => AssertArray(new Godot.Collections.Array()).IsNull())
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(37)
+            .HasFileLineNumber(26)
             .HasMessage("""
                     Expecting be <Null>:
                      but is
@@ -44,18 +33,19 @@ public partial class EnumerableAssertTest
                     """);
     }
 
-    [TestCase]
-    public void IsNotNull()
+    [TestCase(0, TestName = "Array")]
+    [TestCase(1, TestName = "List")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void IsNotNull(int dataIndex)
     {
-        AssertArray(Array.Empty<object>()).IsNotNull();
-        AssertArray(Array.Empty<int>()).IsNotNull();
-        AssertArray(Array.Empty<int>()).IsNotNull();
-        AssertArray(new Godot.Collections.Array()).IsNotNull();
+        dynamic current = TestDataPointEmptyArrays[dataIndex];
 
+        AssertArray(current).IsNotNull();
         // should fail because the current is null
         AssertThrown(() => AssertArray(null).IsNotNull())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(56)
+            .HasFileLineNumber(46)
             .HasMessage("Expecting be NOT <Null>:");
     }
 
@@ -64,12 +54,22 @@ public partial class EnumerableAssertTest
     {
         AssertArray(Array.Empty<object>()).IsEqual(Array.Empty<object>());
         AssertArray(Array.Empty<int>()).IsEqual(Array.Empty<int>());
-        AssertArray(Array.Empty<int>()).IsEqual(Array.Empty<int>());
-        AssertArray(new Godot.Collections.Array()).IsEqual(new Godot.Collections.Array());
         AssertArray(new int[] { 1, 2, 4, 5 }).IsEqual(new int[] { 1, 2, 4, 5 });
-        AssertArray(new Godot.Collections.Array(new Variant[] { 1, 2, 4, 5 })).IsEqual(new Godot.Collections.Array(new Variant[] { 1, 2, 4, 5 }));
+        AssertArray(new Godot.Collections.Array()).IsEqual(new Godot.Collections.Array());
+        AssertArray(new Godot.Collections.Array<Variant>()).IsEqual(new Godot.Collections.Array<Variant>());
+        AssertArray(new Godot.Collections.Array { 1, 2, 3, 4 }).IsEqual(new Godot.Collections.Array { 1, 2, 3, 4 });
+        AssertArray(new Godot.Collections.Array<Variant> { 1, 2, 4, 5 }).IsEqual(new Godot.Collections.Array<Variant> { 1, 2, 4, 5 });
 
         AssertThrown(() => AssertArray(new int[] { 1, 2, 4, 5 }).IsEqual(new int[] { 1, 2, 3, 4, 2, 5 }))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(63)
+            .HasMessage("""
+                    Expecting be equal:
+                        [1, 2, 3, 4, 2, 5]
+                     but is
+                        [1, 2, 4, 5]
+                    """);
+        AssertThrown(() => AssertArray(new Godot.Collections.Array<Variant> { 1, 2, 4, 5 }).IsEqual(new Godot.Collections.Array<Variant> { 1, 2, 3, 4, 2, 5 }))
             .IsInstanceOf<TestFailedException>()
             .HasFileLineNumber(72)
             .HasMessage("""
@@ -78,18 +78,9 @@ public partial class EnumerableAssertTest
                      but is
                         [1, 2, 4, 5]
                     """);
-        AssertThrown(() => AssertArray(new Godot.Collections.Array(new Variant[] { 1, 2, 4, 5 })).IsEqual(new Godot.Collections.Array(new Variant[] { 1, 2, 3, 4, 2, 5 })))
+        AssertThrown(() => AssertArray<object>(null).IsEqual(Array.Empty<object>()))
             .IsInstanceOf<TestFailedException>()
             .HasFileLineNumber(81)
-            .HasMessage("""
-                    Expecting be equal:
-                        [1, 2, 3, 4, 2, 5]
-                     but is
-                        [1, 2, 4, 5]
-                    """);
-        AssertThrown(() => AssertArray(null).IsEqual(Array.Empty<object>()))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(90)
             .HasMessage("""
                     Expecting be equal:
                         <Empty>
@@ -101,22 +92,37 @@ public partial class EnumerableAssertTest
     [TestCase]
     public void IsEqualIgnoringCase()
     {
-        AssertArray(new string[] { "this", "is", "a", "message" }).IsEqualIgnoringCase(new string[] { "This", "is", "a", "Message" });
+        AssertArray(new string[] { "this", "is", "a", "message" })
+            .IsEqualIgnoringCase(new string[] { "This", "is", "a", "Message" });
+        AssertArray(new List<string> { "this", "is", "a", "message" })
+            .IsEqualIgnoringCase(new List<string> { "This", "is", "a", "Message" });
+        AssertArray(new Godot.Collections.Array { "this", "is", "a", "message" })
+            .IsEqualIgnoringCase(new Godot.Collections.Array { "This", "is", "a", "Message" });
+        AssertArray(new Godot.Collections.Array<string> { "this", "is", "a", "message" })
+            .IsEqualIgnoringCase(new Godot.Collections.Array<string> { "This", "is", "a", "Message" });
         // should fail because the array not contains same elements
         AssertThrown(() => AssertArray(new string[] { "this", "is", "a", "message" })
                 .IsEqualIgnoringCase(new string[] { "This", "is", "an", "Message" }))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(106)
+            .HasFileLineNumber(104)
             .HasMessage("""
                     Expecting be equal (ignoring case):
                         ["This", "is", "an", "Message"]
                      but is
                         ["this", "is", "a", "message"]
                     """);
-        AssertThrown(() => AssertArray(null)
+        AssertThrown(() => AssertArray(new Godot.Collections.Array { "this", "is", "a", "message" })
+                .IsEqualIgnoringCase(new Godot.Collections.Array { "This", "is", "an", "Message" }))
+            .IsInstanceOf<TestFailedException>()
+            .HasMessage("""
+                    Expecting be equal (ignoring case):
+                        ["This", "is", "an", "Message"]
+                     but is
+                        ["this", "is", "a", "message"]
+                    """);
+        AssertThrown(() => AssertArray<object>(null)
                .IsEqualIgnoringCase(new string[] { "This", "is" }))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(116)
             .HasMessage("""
                     Expecting be equal (ignoring case):
                         ["This", "is"]
@@ -128,12 +134,23 @@ public partial class EnumerableAssertTest
     [TestCase]
     public void IsNotEqual()
     {
-        AssertArray(null).IsNotEqual(new int[] { 1, 2, 3, 4, 5 });
+        AssertArray<int>(null).IsNotEqual(new int[] { 1, 2, 3, 4, 5 });
         AssertArray(new int[] { 1, 2, 3, 4, 5 }).IsNotEqual(new int[] { 1, 2, 3, 4, 5, 6 });
+        AssertArray(new List<int> { 1, 2, 3, 4, 5 }).IsNotEqual(new List<int> { 1, 2, 3, 4, 5, 6 });
+        AssertArray(new Godot.Collections.Array { 1, 2, 3, 4, 5 }).IsNotEqual(new Godot.Collections.Array { 1, 2, 3, 4, 5, 6 });
+        AssertArray(new Godot.Collections.Array<int> { 1, 2, 3, 4, 5 }).IsNotEqual(new Godot.Collections.Array<int> { 1, 2, 3, 4, 5, 6 });
         // should fail because the array  contains same elements
         AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).IsNotEqual(new int[] { 1, 2, 3, 4, 5 }))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(134)
+            .HasFileLineNumber(143)
+            .HasMessage("""
+                    Expecting be NOT equal:
+                        [1, 2, 3, 4, 5]
+                     but is
+                        [1, 2, 3, 4, 5]
+                    """);
+        AssertThrown(() => AssertArray(new Godot.Collections.Array { 1, 2, 3, 4, 5 }).IsNotEqual(new Godot.Collections.Array { 1, 2, 3, 4, 5 }))
+            .IsInstanceOf<TestFailedException>()
             .HasMessage("""
                     Expecting be NOT equal:
                         [1, 2, 3, 4, 5]
@@ -147,11 +164,14 @@ public partial class EnumerableAssertTest
     {
         AssertArray(null).IsNotEqualIgnoringCase(new string[] { "This", "is", "an", "Message" });
         AssertArray(new string[] { "this", "is", "a", "message" }).IsNotEqualIgnoringCase(new string[] { "This", "is", "an", "Message" });
+        AssertArray(new List<string> { "this", "is", "a", "message" }).IsNotEqualIgnoringCase(new List<string> { "This", "is", "an", "Message" });
+        AssertArray(new Godot.Collections.Array { "this", "is", "a", "message" }).IsNotEqualIgnoringCase(new Godot.Collections.Array { "This", "is", "an", "Message" });
+        AssertArray(new Godot.Collections.Array<string> { "this", "is", "a", "message" }).IsNotEqualIgnoringCase(new Godot.Collections.Array<string> { "This", "is", "an", "Message" });
         // should fail because the array contains same elements ignoring case sensitive
         AssertThrown(() => AssertArray(new string[] { "this", "is", "a", "message" })
                 .IsNotEqualIgnoringCase(new string[] { "This", "is", "a", "Message" }))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(151)
+            .HasFileLineNumber(171)
             .HasMessage("""
                     Expecting be NOT equal (ignoring case):
                         ["This", "is", "a", "Message"]
@@ -160,555 +180,582 @@ public partial class EnumerableAssertTest
                     """);
     }
 
-    [TestCase]
-    public void IsEmpty()
+    [TestCase(0, TestName = "Array")]
+    [TestCase(1, TestName = "List")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void IsEmpty(int dataIndex)
     {
-        AssertArray(Array.Empty<int>()).IsEmpty();
+        dynamic empty = TestDataPointEmptyArrays[dataIndex];
+        dynamic? expected = TestDataPointStringValues[dataIndex] as object[];
+        dynamic filled = expected![0];
+
+        AssertArray(empty).IsEmpty();
         // should fail because the array is not empty it has a size of one
-        AssertThrown(() => AssertArray(new int[] { 1 }).IsEmpty())
+        AssertThrown(() => AssertArray(filled).IsEmpty())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(168)
+            .HasFileLineNumber(195)
             .HasMessage("""
                     Expecting be empty:
-                     but has size '1'
-                    """);
-        AssertThrown(() => AssertArray(null).IsEmpty())
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(175)
-            .HasMessage("""
-                    Expecting be empty:
-                     but is <Null>
+                     but has size '4'
                     """);
     }
 
-    [TestCase]
-    public void IsNotEmpty()
+    [TestCase(0, TestName = "Array")]
+    [TestCase(1, TestName = "List")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void IsNotEmpty(int dataIndex)
     {
+        dynamic empty = TestDataPointEmptyArrays[dataIndex];
+        dynamic? expected = TestDataPointStringValues[dataIndex] as object[];
+        dynamic filled = expected![0];
+
         AssertArray(null).IsNotEmpty();
-        AssertArray(new int[] { 1 }).IsNotEmpty();
+        AssertArray(filled).IsNotEmpty();
         // should fail because the array is empty
-        AssertThrown(() => AssertArray(Array.Empty<int>()).IsNotEmpty())
+        AssertThrown(() => AssertArray(empty).IsNotEmpty())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(190)
+            .HasFileLineNumber(217)
             .HasMessage("""
                     Expecting being NOT empty:
                      but is empty
                     """);
     }
 
-    [TestCase]
-    public void HasSize()
+
+    [TestCase(0, TestName = "Array")]
+    [TestCase(1, TestName = "List")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void HasSize(int dataIndex)
     {
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).HasSize(5);
-        AssertArray(new string[] { "a", "b", "c", "d", "e", "f" }).HasSize(6);
-        // should fail because the array has a size of 5
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).HasSize(4))
+        dynamic? expected = TestDataPointStringValues[dataIndex] as object[];
+        dynamic current = expected![0];
+
+        AssertArray(current).HasSize(4);
+        // should fail because the array has a size of 4
+        AssertThrown(() => AssertArray(current).HasSize(5))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(205)
+            .HasFileLineNumber(238)
             .HasMessage("""
                     Expecting size:
-                        '4' but is '5'
+                        '5' but is '4'
                     """);
         AssertThrown(() => AssertArray(null).HasSize(4))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(212)
             .HasMessage("""
                     Expecting size:
                         '4' but is unknown
                     """);
     }
 
-    [TestCase]
-    public void ContainsStringsAsArray()
+    [TestCase(0, TestName = "Array<string>")]
+    [TestCase(1, TestName = "List<string>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<string>")]
+    public void ContainsOnStrings(int testDataIndex)
     {
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).Contains(Array.Empty<string>());
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).Contains(new string[] { "ddd", "bbb" });
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).Contains(new string[] { "eee", "ddd", "ccc", "bbb", "aaa" });
-        // should fail because the array not contains 'xxx' and 'yyy'
-        AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).Contains(new string[] { "bbb", "xxx", "yyy" }))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(228)
-            .HasMessage("""
-                    Expecting contains elements:
-                        ["aaa", "bbb", "ccc", "ddd", "eee"]
-                     do contains (in any order)
-                        ["bbb", "xxx", "yyy"]
-                     but could not find elements:
-                        ["xxx", "yyy"]
-                    """);
-        AssertThrown(() => AssertArray(null).Contains(new string[] { "bbb", "xxx", "yyy" }))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(239)
-            .HasMessage("""
-                    Expecting contains elements:
-                        <Null>
-                     do contains (in any order)
-                        ["bbb", "xxx", "yyy"]
-                     but could not find elements:
-                        ["bbb", "xxx", "yyy"]
-                    """);
-    }
+        var testData = TestDataPointStringValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
 
-    [TestCase]
-    public void ContainsStringsAsElements()
-    {
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).Contains();
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).Contains("ddd", "bbb");
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).Contains("eee", "ddd", "ccc", "bbb", "aaa");
-        // should fail because the array not contains 7 and 6
-        AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).Contains("bbb", "xxx", "yyy"))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(259)
-            .HasMessage("""
-                    Expecting contains elements:
-                        ["aaa", "bbb", "ccc", "ddd", "eee"]
-                     do contains (in any order)
-                        ["bbb", "xxx", "yyy"]
-                     but could not find elements:
-                        ["xxx", "yyy"]
-                    """);
-    }
-
-    [TestCase]
-    public void ContainsNumbersAsArray()
-    {
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).Contains(Array.Empty<int>());
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).Contains(new int[] { 5, 2 });
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).Contains(new int[] { 5, 4, 3, 2, 1 });
-        // should fail because the array not contains 7 and 6
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).Contains(new int[] { 2, 7, 6 }))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(279)
-            .HasMessage("""
-                    Expecting contains elements:
-                        [1, 2, 3, 4, 5]
-                     do contains (in any order)
-                        [2, 7, 6]
-                     but could not find elements:
-                        [7, 6]
-                    """);
-    }
-
-    [TestCase]
-    public void ContainsNumbersAsElements()
-    {
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).Contains();
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).Contains(5, 2);
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).Contains(5, 4, 3, 2, 1);
-        // should fail because the array not contains 7 and 6
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).Contains(2, 7, 6))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(299)
-            .HasMessage("""
-                    Expecting contains elements:
-                        [1, 2, 3, 4, 5]
-                     do contains (in any order)
-                        [2, 7, 6]
-                     but could not find elements:
-                        [7, 6]
-                    """);
-    }
-
-    [TestCase]
-    public void ContainsExactlyStringsAsArray()
-    {
         // test against only one element
-        AssertArray(new string[] { "abc" }).ContainsExactly(new string[] { "abc" });
-        AssertThrown(() => AssertArray(new string[] { "abc" }).ContainsExactly(new string[] { "abXc" }))
+        AssertArray(current).Contains(obj1);
+        AssertArray(current).Contains(obj2);
+        AssertArray(current).Contains(obj2, obj3);
+        AssertArray(current).Contains(obj1, obj2, obj3, obj4);
+        AssertArray(current).Contains(obj4, obj1, obj3, obj2);
+        AssertArray(current).Contains(current);
+        AssertThrown(() => AssertArray(current).Contains(obj5))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(317)
+            .HasFileLineNumber(274)
             .HasMessage("""
-                    Expecting contains exactly elements:
-                        ["abc"]
-                     do contains (in same order)
-                        ["abXc"]
-                     but some elements where not expected:
-                        ["abc"]
-                     and could not find elements:
-                        ["abXc"]
-                    """);
-
-        // test against many elements
-        AssertArray(new string[] { "abc", "def", "xyz" }).ContainsExactly(new string[] { "abc", "def", "xyz" });
-        // should fail because if contains the same elements but in a different order
-        AssertThrown(() => AssertArray(new string[] { "abc", "def", "xyz" }).ContainsExactly(new string[] { "abc", "xyz", "def" }))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(334)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        ["abc", "def", "xyz"]
-                     do contains (in same order)
-                        ["abc", "xyz", "def"]
-                     but has different order at position '1'
-                        "def" vs "xyz"
-                    """);
-
-        // should fail because it contains more elements and in a different order
-        AssertThrown(() => AssertArray(new string[] { "abc", "def", "foo", "bar", "xyz" }).ContainsExactly(new string[] { "abc", "xyz", "def" }))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(347)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        ["abc", "def", "foo", "bar", "xyz"]
-                     do contains (in same order)
-                        ["abc", "xyz", "def"]
-                     but some elements where not expected:
-                        ["foo", "bar"]
-                    """);
-
-        // should fail because it contains less elements and in a different order
-        AssertThrown(() => AssertArray(new string[] { "abc", "def", "xyz" }).ContainsExactly(new string[] { "abc", "def", "bar", "foo", "xyz" }))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(360)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        ["abc", "def", "xyz"]
-                     do contains (in same order)
-                        ["abc", "def", "bar", "foo", "xyz"]
+                    Expecting contains elements:
+                        ["a", "b", "c", "a"]
+                     do contains (in any order)
+                        ["X"]
                      but could not find elements:
-                        ["bar", "foo"]
+                        ["X"]
                     """);
-        AssertThrown(() => AssertArray(null).ContainsExactly(new string[] { "abc", "def", "bar", "foo", "xyz" }))
+
+        AssertThrown(() => AssertArray(current).Contains(obj1, obj2, obj5))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(371)
+            .HasFileLineNumber(286)
             .HasMessage("""
-                    Expecting contains exactly elements:
-                        <Null>
-                     do contains (in same order)
-                        ["abc", "def", "bar", "foo", "xyz"]
+                    Expecting contains elements:
+                        ["a", "b", "c", "a"]
+                     do contains (in any order)
+                        ["a", "b", "X"]
                      but could not find elements:
-                        ["abc", "def", "bar", "foo", "xyz"]
+                        ["X"]
                     """);
     }
 
-    [TestCase]
-    public void ContainsExactlyStringsAsElements()
+    [TestCase(0, TestName = "Array<object>")]
+    [TestCase(1, TestName = "List<object>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void ContainsOnObjects(int testDataIndex)
     {
+        var testData = TestDataPointObjectValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
         // test against only one element
-        AssertArray(new string[] { "abc" }).ContainsExactly("abc");
-        AssertThrown(() => AssertArray(new string[] { "abc" }).ContainsExactly("abXc"))
+        AssertArray(current).Contains(obj1);
+        AssertArray(current).Contains(obj2);
+        AssertArray(current).Contains(obj2, obj3);
+        AssertArray(current).Contains(obj1, obj2, obj3, obj4);
+        AssertArray(current).Contains(obj4, obj1, obj3, obj2);
+        AssertArray(current).Contains(current);
+        AssertThrown(() => AssertArray(current).Contains(obj5))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(389)
+            .HasFileLineNumber(320)
             .HasMessage("""
-                    Expecting contains exactly elements:
-                        ["abc"]
-                     do contains (in same order)
-                        ["abXc"]
-                     but some elements where not expected:
-                        ["abc"]
-                     and could not find elements:
-                        ["abXc"]
-                    """);
-        // test against many elements
-        AssertArray(new string[] { "abc", "def", "xyz" }).ContainsExactly("abc", "def", "xyz");
-        // should fail because if contains the same elements but in a different order
-        AssertThrown(() => AssertArray(new string[] { "abc", "def", "xyz" }).ContainsExactly("abc", "xyz", "def"))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(405)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        ["abc", "def", "xyz"]
-                     do contains (in same order)
-                        ["abc", "xyz", "def"]
-                     but has different order at position '1'
-                        "def" vs "xyz"
-                    """);
-        // should fail because it contains more elements and in a different order
-        AssertThrown(() => AssertArray(new string[] { "abc", "def", "foo", "bar", "xyz" }).ContainsExactly("abc", "xyz", "def"))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(417)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        ["abc", "def", "foo", "bar", "xyz"]
-                     do contains (in same order)
-                        ["abc", "xyz", "def"]
-                     but some elements where not expected:
-                        ["foo", "bar"]
-                    """);
-        // should fail because it contains less elements and in a different order
-        AssertThrown(() => AssertArray(new string[] { "abc", "def", "xyz" }).ContainsExactly("abc", "def", "bar", "foo", "xyz"))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(429)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        ["abc", "def", "xyz"]
-                     do contains (in same order)
-                        ["abc", "def", "bar", "foo", "xyz"]
+                    Expecting contains elements:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do contains (in any order)
+                        [$obj5]
                      but could not find elements:
-                        ["bar", "foo"]
-                    """);
+                        [$obj5]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
+
+        AssertThrown(() => AssertArray(current).Contains(obj1, obj2, obj5))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(337)
+            .HasMessage("""
+                    Expecting contains elements:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do contains (in any order)
+                        [$obj1, $obj2, $obj5]
+                     but could not find elements:
+                        [$obj5]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
     }
 
-    [TestCase]
-    public void ContainsExactlyNumbersAsArray()
+    [TestCase(0, TestName = "Array<string>")]
+    [TestCase(1, TestName = "List<string>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<string>")]
+    public void ContainsExactlyOnStrings(int testDataIndex)
     {
-        // test against array with only one element
-        AssertArray(new int[] { 1 }).ContainsExactly(new int[] { 1 });
-        AssertThrown(() => AssertArray(new int[] { 1 }).ContainsExactly(new int[] { 2 }))
+        var testData = TestDataPointStringValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
+        // test against only one element
+        AssertArray(current).ContainsExactly(obj1, obj2, obj3, obj4);
+        AssertArray(current).ContainsExactly(obj1, obj2, obj3, obj1);
+        AssertArray(current).ContainsExactly(current);
+        AssertThrown(() => AssertArray(current).ContainsExactly(obj1))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(447)
+            .HasFileLineNumber(373)
             .HasMessage("""
                     Expecting contains exactly elements:
-                        [1]
+                        ["a", "b", "c", "a"]
                      do contains (in same order)
-                        [2]
-                     but some elements where not expected:
-                        [1]
-                     and could not find elements:
-                        [2]
+                        ["a"]
+                     but others where not expected:
+                        ["b", "c", "a"]
                     """);
-        // test against array with many elements
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactly(new int[] { 1, 2, 3, 4, 5 });
-        // should fail because if contains the same elements but in a different order
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactly(new int[] { 1, 4, 3, 2, 5 }))
+        AssertThrown(() => AssertArray(current).ContainsExactly(obj1, obj2))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(463)
+            .HasFileLineNumber(384)
             .HasMessage("""
                     Expecting contains exactly elements:
-                        [1, 2, 3, 4, 5]
+                        ["a", "b", "c", "a"]
                      do contains (in same order)
-                        [1, 4, 3, 2, 5]
-                     but has different order at position '1'
-                        '2' vs '4'
+                        ["a", "b"]
+                     but others where not expected:
+                        ["c", "a"]
                     """);
-        // should fail because it contains more elements and in a different order
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5, 6, 7 }).ContainsExactly(new int[] { 1, 4, 3, 2, 5 }))
+        AssertThrown(() => AssertArray(current).ContainsExactly(obj1, obj5))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(475)
+            .HasFileLineNumber(395)
             .HasMessage("""
                     Expecting contains exactly elements:
-                        [1, 2, 3, 4, 5, 6, 7]
+                        ["a", "b", "c", "a"]
                      do contains (in same order)
-                        [1, 4, 3, 2, 5]
-                     but some elements where not expected:
-                        [6, 7]
+                        ["a", "X"]
+                     but others where not expected:
+                        ["b", "c", "a"]
+                     and some elements not found:
+                        ["X"]
                     """);
-        // should fail because it contains less elements and in a different order
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactly(new int[] { 1, 4, 3, 2, 5, 6, 7 }))
+        AssertThrown(() => AssertArray(current).ContainsExactly(obj1, obj3, obj2, obj4))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(408)
+            .HasMessage("""
+                Expecting contains exactly elements:
+                    ["a", "b", "c", "a"]
+                 do contains (in same order)
+                    ["a", "c", "b", "a"]
+                 but there has differences in order:
+                    - element at index 0 expect "c" but is "b"
+                    - element at index 1 expect "b" but is "c"
+                """);
+    }
+
+    [TestCase(0, TestName = "Array<object>")]
+    [TestCase(1, TestName = "List<object>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void ContainsExactlyOnObjects(int testDataIndex)
+    {
+        var testData = TestDataPointObjectValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
+        // test against only one element
+        AssertArray(current).ContainsExactly(obj1, obj2, obj3, obj4);
+        AssertArray(current).ContainsExactly(current);
+        AssertThrown(() => AssertArray(current).ContainsExactly(obj1))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(439)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do contains (in same order)
+                        [$obj1]
+                     but others where not expected:
+                        [$obj2, $obj3, $obj4]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4)));
+        AssertThrown(() => AssertArray(current).ContainsExactly(obj1, obj2))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(454)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do contains (in same order)
+                        [$obj1, $obj2]
+                     but others where not expected:
+                        [$obj3, $obj4]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4)));
+        AssertThrown(() => AssertArray(current).ContainsExactly(obj1, obj5))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(469)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do contains (in same order)
+                        [$obj1, $obj5]
+                     but others where not expected:
+                        [$obj2, $obj3, $obj4]
+                     and some elements not found:
+                        [$obj5]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
+        AssertThrown(() => AssertArray(current).ContainsExactly(obj1, obj3, obj2, obj4))
             .IsInstanceOf<TestFailedException>()
             .HasFileLineNumber(487)
             .HasMessage("""
-                    Expecting contains exactly elements:
-                        [1, 2, 3, 4, 5]
-                     do contains (in same order)
-                        [1, 4, 3, 2, 5, 6, 7]
-                     but could not find elements:
-                        [6, 7]
-                    """);
+                Expecting contains exactly elements:
+                    [$obj1, $obj2, $obj3, $obj4]
+                 do contains (in same order)
+                    [$obj1, $obj3, $obj2, $obj4]
+                 but there has differences in order:
+                    - element at index 0 expect $obj3 but is $obj2
+                    - element at index 1 expect $obj2 but is $obj3
+                """
+                    .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                    .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                    .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                    .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                    .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
     }
 
-    [TestCase]
-    public void ContainsExactlyNumbersAsElements()
+    [TestCase(0, TestName = "Array<string>")]
+    [TestCase(1, TestName = "List<string>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<string>")]
+    public void ContainsExactlyInAnyOrderOnString(int testDataIndex)
     {
-        // test against array with only one element
-        AssertArray(new int[] { 1 }).ContainsExactly(1);
-        AssertThrown(() => AssertArray(new int[] { 1 }).ContainsExactly(2))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(505)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        [1]
-                     do contains (in same order)
-                        [2]
-                     but some elements where not expected:
-                        [1]
-                     and could not find elements:
-                        [2]
-                    """);
-        // test against array with many elements
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactly(1, 2, 3, 4, 5);
-        // should fail because if contains the same elements but in a different order
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactly(1, 4, 3, 2, 5))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(521)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        [1, 2, 3, 4, 5]
-                     do contains (in same order)
-                        [1, 4, 3, 2, 5]
-                     but has different order at position '1'
-                        '2' vs '4'
-                    """);
-        // should fail because it contains more elements and in a different order
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5, 6, 7 }).ContainsExactly(1, 4, 3, 2, 5))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(533)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        [1, 2, 3, 4, 5, 6, 7]
-                     do contains (in same order)
-                        [1, 4, 3, 2, 5]
-                     but some elements where not expected:
-                        [6, 7]
-                    """);
-        // should fail because it contains less elements and in a different order
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactly(1, 4, 3, 2, 5, 6, 7))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(545)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        [1, 2, 3, 4, 5]
-                     do contains (in same order)
-                        [1, 4, 3, 2, 5, 6, 7]
-                     but could not find elements:
-                        [6, 7]
-                    """);
-    }
+        var testData = TestDataPointStringValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
 
-    [TestCase]
-    public void ContainsExactlyInAnyOrderStringsAsArray()
-    {
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).ContainsExactlyInAnyOrder(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" });
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).ContainsExactlyInAnyOrder(new string[] { "eee", "ddd", "ccc", "bbb", "aaa" });
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).ContainsExactlyInAnyOrder(new string[] { "bbb", "aaa", "ccc", "eee", "ddd" });
-
+        AssertArray(current).ContainsExactlyInAnyOrder(current);
+        AssertArray(current).ContainsExactlyInAnyOrder(obj1, obj2, obj3, obj4);
+        AssertArray(current).ContainsExactlyInAnyOrder(obj4, obj2, obj3, obj1);
+        AssertArray(current).ContainsExactlyInAnyOrder(obj2, obj4, obj3, obj1);
+        if (obj1 is Variant)
+        {
+            AssertArray(current).ContainsExactlyInAnyOrder(new Variant[] { obj1, obj2, obj3, obj4 });
+            AssertArray(current).ContainsExactlyInAnyOrder(new Variant[] { obj4, obj2, obj3, obj1 });
+        }
+        else
+        {
+            AssertArray(current).ContainsExactlyInAnyOrder(new string[] { obj1, obj2, obj3, obj4 });
+            AssertArray(current).ContainsExactlyInAnyOrder(new string[] { obj4, obj2, obj3, obj1 });
+        }
         // should fail because is contains not exactly the same elements in any order
-        AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd" })
-                .ContainsExactlyInAnyOrder(new string[] { "xxx", "aaa", "yyy", "bbb", "ccc", "ddd" }))
+        AssertThrown(() => AssertArray(current)
+                .ContainsExactlyInAnyOrder(obj1, obj2, obj5, obj3, obj4))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(566)
+            .HasFileLineNumber(535)
             .HasMessage("""
                     Expecting contains exactly elements:
-                        ["aaa", "bbb", "ccc", "ddd"]
+                        ["a", "b", "c", "a"]
                      do contains (in any order)
-                        ["xxx", "aaa", "yyy", "bbb", "ccc", "ddd"]
+                        ["a", "b", "X", "c", "a"]
                      but could not find elements:
-                        ["xxx", "yyy"]
+                        ["X"]
                     """);
-        //should fail because is contains the same elements but in a different order
-        AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee", "fff" })
-                .ContainsExactlyInAnyOrder(new string[] { "fff", "aaa", "ddd", "bbb", "eee", }))
+        //should fail because is contains not all elements
+        AssertThrown(() => AssertArray(current)
+                .ContainsExactlyInAnyOrder(obj1, obj2, obj4))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(579)
+            .HasFileLineNumber(548)
             .HasMessage("""
                     Expecting contains exactly elements:
-                        ["aaa", "bbb", "ccc", "ddd", "eee", "fff"]
+                        ["a", "b", "c", "a"]
                      do contains (in any order)
-                        ["fff", "aaa", "ddd", "bbb", "eee"]
+                        ["a", "b", "a"]
                      but some elements where not expected:
-                        ["ccc"]
-                    """);
-        AssertThrown(() => AssertArray(null)
-                .ContainsExactlyInAnyOrder(new string[] { "fff", "aaa", "ddd", "bbb", "eee", }))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(591)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        <Null>
-                     do contains (in any order)
-                        ["fff", "aaa", "ddd", "bbb", "eee"]
-                     but could not find elements:
-                        ["fff", "aaa", "ddd", "bbb", "eee"]
+                        ["c"]
                     """);
     }
 
-    [TestCase]
-    public void ContainsExactlyInAnyOrderStringsAsElements()
+    [TestCase(0, TestName = "Array<object>")]
+    [TestCase(1, TestName = "List<object>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void ContainsExactlyInAnyOrderOnObject(int testDataIndex)
     {
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).ContainsExactlyInAnyOrder("aaa", "bbb", "ccc", "ddd", "eee");
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).ContainsExactlyInAnyOrder("eee", "ddd", "ccc", "bbb", "aaa");
-        AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee" }).ContainsExactlyInAnyOrder("bbb", "aaa", "ccc", "eee", "ddd");
+        var testData = TestDataPointObjectValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
 
+        AssertArray(current).ContainsExactlyInAnyOrder(current);
+        AssertArray(current).ContainsExactlyInAnyOrder(obj1, obj2, obj3, obj4);
+        AssertArray(current).ContainsExactlyInAnyOrder(obj4, obj2, obj3, obj1);
+        AssertArray(current).ContainsExactlyInAnyOrder(obj2, obj4, obj3, obj1);
+        if (obj1 is Variant)
+        {
+            AssertArray(current).ContainsExactlyInAnyOrder(new Variant[] { obj1, obj2, obj3, obj4 });
+            AssertArray(current).ContainsExactlyInAnyOrder(new Variant[] { obj4, obj2, obj3, obj1 });
+        }
+        else if (obj1 is RefCounted)
+        {
+            AssertArray(current).ContainsExactlyInAnyOrder(new RefCounted[] { obj1, obj2, obj3, obj4 });
+            AssertArray(current).ContainsExactlyInAnyOrder(new RefCounted[] { obj4, obj2, obj3, obj1 });
+        }
+        else
+        {
+            AssertArray(current).ContainsExactlyInAnyOrder(new object[] { obj1, obj2, obj3, obj4 });
+            AssertArray(current).ContainsExactlyInAnyOrder(new object[] { obj4, obj2, obj3, obj1 });
+        }
         // should fail because is contains not exactly the same elements in any order
-        AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd" })
-                .ContainsExactlyInAnyOrder("xxx", "aaa", "yyy", "bbb", "ccc", "ddd"))
+        AssertThrown(() => AssertArray(current)
+                .ContainsExactlyInAnyOrder(obj1, obj2, obj5, obj3, obj4))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(613)
+            .HasFileLineNumber(596)
             .HasMessage("""
                     Expecting contains exactly elements:
-                        ["aaa", "bbb", "ccc", "ddd"]
+                        [$obj1, $obj2, $obj3, $obj4]
                      do contains (in any order)
-                        ["xxx", "aaa", "yyy", "bbb", "ccc", "ddd"]
+                        [$obj1, $obj2, $obj5, $obj3, $obj4]
                      but could not find elements:
-                        ["xxx", "yyy"]
-                    """);
-        //should fail because is contains the same elements but in a different order
-        AssertThrown(() => AssertArray(new string[] { "aaa", "bbb", "ccc", "ddd", "eee", "fff" })
-                .ContainsExactlyInAnyOrder("fff", "aaa", "ddd", "bbb", "eee"))
+                        [$obj5]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
+        //should fail because is contains not all elements
+        AssertThrown(() => AssertArray(current)
+                .ContainsExactlyInAnyOrder(obj1, obj2, obj4))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(626)
+            .HasFileLineNumber(614)
             .HasMessage("""
                     Expecting contains exactly elements:
-                        ["aaa", "bbb", "ccc", "ddd", "eee", "fff"]
+                        [$obj1, $obj2, $obj3, $obj4]
                      do contains (in any order)
-                        ["fff", "aaa", "ddd", "bbb", "eee"]
+                        [$obj1, $obj2, $obj4]
                      but some elements where not expected:
-                        ["ccc"]
+                        [$obj3]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
+    }
+
+
+    [TestCase(0, TestName = "Array<string>")]
+    [TestCase(1, TestName = "List<string>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<string>")]
+    public void ContainsSameExactlyInAnyOrderOnString(int testDataIndex)
+    {
+        var testData = TestDataPointStringValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
+        AssertArray(current).ContainsSameExactlyInAnyOrder(current);
+        AssertArray(current).ContainsSameExactlyInAnyOrder(obj1, obj2, obj3, obj4);
+        AssertArray(current).ContainsSameExactlyInAnyOrder(obj4, obj2, obj3, obj1);
+        AssertArray(current).ContainsSameExactlyInAnyOrder(obj2, obj4, obj3, obj1);
+        if (obj1 is Variant)
+        {
+            AssertArray(current).ContainsSameExactlyInAnyOrder(new Variant[] { obj1, obj2, obj3, obj4 });
+            AssertArray(current).ContainsSameExactlyInAnyOrder(new Variant[] { obj4, obj2, obj3, obj1 });
+        }
+        else
+        {
+            AssertArray(current).ContainsSameExactlyInAnyOrder(new string[] { obj1, obj2, obj3, obj4 });
+            AssertArray(current).ContainsSameExactlyInAnyOrder(new string[] { obj4, obj2, obj3, obj1 });
+        }
+        // should fail because is contains not exactly the same elements in any order
+        AssertThrown(() => AssertArray(current)
+                .ContainsSameExactlyInAnyOrder(obj1, obj2, obj5, obj3, obj4))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(663)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        ["a", "b", "c", "a"]
+                     do contains (in any order)
+                        ["a", "b", "X", "c", "a"]
+                     but could not find elements:
+                        ["X"]
+                    """);
+        //should fail because is contains not all elements
+        AssertThrown(() => AssertArray(current)
+                .ContainsSameExactlyInAnyOrder(obj1, obj2, obj4))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(676)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        ["a", "b", "c", "a"]
+                     do contains (in any order)
+                        ["a", "b", "a"]
+                     but some elements where not expected:
+                        ["c"]
                     """);
     }
 
-    [TestCase]
-    public void ContainsExactlyInAnyOrderNumbersAsArray()
+    [TestCase(0, TestName = "Array<object>")]
+    [TestCase(1, TestName = "List<object>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void ContainsSameExactlyInAnyOrderOnObject(int testDataIndex)
     {
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactlyInAnyOrder(new int[] { 1, 2, 3, 4, 5 });
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactlyInAnyOrder(new int[] { 5, 3, 2, 4, 1 });
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactlyInAnyOrder(new int[] { 5, 1, 2, 4, 3 });
+        var testData = TestDataPointObjectValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
 
+        AssertArray(current).ContainsSameExactlyInAnyOrder(current);
+        AssertArray(current).ContainsSameExactlyInAnyOrder(obj1, obj2, obj3, obj4);
+        AssertArray(current).ContainsSameExactlyInAnyOrder(obj4, obj2, obj3, obj1);
+        AssertArray(current).ContainsSameExactlyInAnyOrder(obj2, obj4, obj3, obj1);
+        if (obj1 is Variant)
+        {
+            AssertArray(current).ContainsSameExactlyInAnyOrder(new Variant[] { obj1, obj2, obj3, obj4 });
+            AssertArray(current).ContainsSameExactlyInAnyOrder(new Variant[] { obj4, obj2, obj3, obj1 });
+        }
+        else if (obj1 is RefCounted)
+        {
+            AssertArray(current).ContainsSameExactlyInAnyOrder(new RefCounted[] { obj1, obj2, obj3, obj4 });
+            AssertArray(current).ContainsSameExactlyInAnyOrder(new RefCounted[] { obj4, obj2, obj3, obj1 });
+        }
+        else
+        {
+            AssertArray(current).ContainsSameExactlyInAnyOrder(new object[] { obj1, obj2, obj3, obj4 });
+            AssertArray(current).ContainsSameExactlyInAnyOrder(new object[] { obj4, obj2, obj3, obj1 });
+        }
         // should fail because is contains not exactly the same elements in any order
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 6, 4, 5 }).ContainsExactlyInAnyOrder(new int[] { 5, 3, 2, 4, 1, 9, 10 }))
+        AssertThrown(() => AssertArray(current)
+                .ContainsSameExactlyInAnyOrder(obj1, obj2, obj5, obj3, obj4))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(648)
+            .HasFileLineNumber(724)
             .HasMessage("""
                     Expecting contains exactly elements:
-                        [1, 2, 6, 4, 5]
+                        [$obj1, $obj2, $obj3, $obj4]
                      do contains (in any order)
-                        [5, 3, 2, 4, 1, 9, 10]
-                     but some elements where not expected:
-                        [6]
-                     and could not find elements:
-                        [3, 9, 10]
-                    """);
-        //should fail because is contains the same elements but in a different order
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 6, 9, 10, 4, 5 }).ContainsExactlyInAnyOrder(new int[] { 5, 3, 2, 4, 1 }))
+                        [$obj1, $obj2, $obj5, $obj3, $obj4]
+                     but could not find elements:
+                        [$obj5]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
+        //should fail because is contains not all elements
+        AssertThrown(() => AssertArray(current)
+                .ContainsSameExactlyInAnyOrder(obj1, obj2, obj4))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(662)
+            .HasFileLineNumber(742)
             .HasMessage("""
                     Expecting contains exactly elements:
-                        [1, 2, 6, 9, 10, 4, 5]
+                        [$obj1, $obj2, $obj3, $obj4]
                      do contains (in any order)
-                        [5, 3, 2, 4, 1]
+                        [$obj1, $obj2, $obj4]
                      but some elements where not expected:
-                        [6, 9, 10]
-                     and could not find elements:
-                        [3]
-                    """);
-    }
-
-    [TestCase]
-    public void ContainsExactlyInAnyOrderNumbersAsElements()
-    {
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactlyInAnyOrder(1, 2, 3, 4, 5);
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactlyInAnyOrder(5, 3, 2, 4, 1);
-        AssertArray(new int[] { 1, 2, 3, 4, 5 }).ContainsExactlyInAnyOrder(5, 1, 2, 4, 3);
-
-        // should fail because is contains not exactly the same elements in any order
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 6, 4, 5 }).ContainsExactlyInAnyOrder(5, 3, 2, 4, 1, 9, 10))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(685)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        [1, 2, 6, 4, 5]
-                     do contains (in any order)
-                        [5, 3, 2, 4, 1, 9, 10]
-                     but some elements where not expected:
-                        [6]
-                     and could not find elements:
-                        [3, 9, 10]
-                    """);
-        //should fail because is contains the same elements but in a different order
-        AssertThrown(() => AssertArray(new int[] { 1, 2, 6, 9, 10, 4, 5 }).ContainsExactlyInAnyOrder(5, 3, 2, 4, 1))
-            .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(699)
-            .HasMessage("""
-                    Expecting contains exactly elements:
-                        [1, 2, 6, 9, 10, 4, 5]
-                     do contains (in any order)
-                        [5, 3, 2, 4, 1]
-                     but some elements where not expected:
-                        [6, 9, 10]
-                     and could not find elements:
-                        [3]
-                    """);
+                        [$obj3]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
     }
 
     [TestCase]
@@ -742,13 +789,13 @@ public partial class EnumerableAssertTest
         // must fail we can't extract from a null instance
         AssertThrown(() => AssertArray(null).Extract("GetClass").ContainsExactly("AStar", "Node"))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(743)
+            .HasFileLineNumber(790)
             .HasMessage("""
                     Expecting contains exactly elements:
                         <Null>
                      do contains (in same order)
                         ["AStar", "Node"]
-                     but could not find elements:
+                     but some elements not found:
                         ["AStar", "Node"]
                     """);
     }
@@ -799,13 +846,13 @@ public partial class EnumerableAssertTest
                 .ExtractV(Extr("GetName"), Extr("GetValue"), Extr("GetX"))
                 .ContainsExactly(Tuple("A", 10, null)))
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(798)
+            .HasFileLineNumber(845)
             .HasMessage("""
                     Expecting contains exactly elements:
                         <Null>
                      do contains (in same order)
                         [tuple("A", 10, <Null>)]
-                     but could not find elements:
+                     but some elements not found:
                         [tuple("A", 10, <Null>)]
                     """);
     }
@@ -885,7 +932,7 @@ public partial class EnumerableAssertTest
                 .OverrideFailureMessage("Custom failure message")
                 .IsNull())
             .IsInstanceOf<TestFailedException>()
-            .HasFileLineNumber(884)
+            .HasFileLineNumber(931)
             .HasMessage("Custom failure message");
 
     [TestCase]
@@ -900,4 +947,487 @@ public partial class EnumerableAssertTest
         // expect this line will never called because of the test is interrupted by a failing assert
         AssertBool(true).OverrideFailureMessage("This line should never be called").IsFalse();
     }
+
+    [TestCase(0, TestName = "Array")]
+    [TestCase(1, TestName = "List<string>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<string>")]
+    public void IsSame(int dataPointIndex)
+    {
+        var dataPoint = TestDataPointStringValues[dataPointIndex] as object[];
+        dynamic current = dataPoint![0];
+        dynamic other = dataPoint![1];
+        AssertArray(current).IsSame(current);
+
+        AssertThrown(() => AssertArray(current).IsSame(other))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(962)
+            .HasMessage("""
+                Expecting be same:
+                    ["a", "b", "c", "a"]
+                 to refer to the same object
+                    ["a", "b", "c", "a"]
+                """);
+    }
+
+    [TestCase(0, TestName = "Array")]
+    [TestCase(1, TestName = "List<string>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<string>")]
+    public void IsNotSame(int dataPointIndex)
+    {
+        var dataPoint = TestDataPointStringValues[dataPointIndex] as object[];
+        dynamic current = dataPoint![0];
+        dynamic other = dataPoint![1];
+        AssertArray(current).IsNotSame(other);
+
+        AssertThrown(() => AssertArray(current).IsNotSame(current))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(984)
+            .HasMessage("""
+                Expecting be NOT same: ["a", "b", "c", "a"]
+                """);
+    }
+
+    [TestCase(0, TestName = "Array")]
+    [TestCase(1, TestName = "List<string>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<string>")]
+    public void ContainsSameOnString(int dataPointIndex)
+    {
+        var testData = TestDataPointStringValues[dataPointIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
+        AssertArray(current).ContainsSame(obj1);
+        AssertArray(current).ContainsSame(obj2);
+        AssertArray(current).ContainsSame(obj2, obj3);
+        AssertArray(current).ContainsSame(obj1, obj2, obj3, obj4);
+        AssertArray(current).ContainsSame(obj4, obj1, obj3, obj2);
+        AssertArray(current).ContainsSame(current);
+        // should fail because the array not contains 'xxx' and 'yyy'
+        AssertThrown(() => AssertArray(current).ContainsSame(obj1, obj5))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1013)
+            .HasMessage("""
+                    Expecting contains elements:
+                        ["a", "b", "c", "a"]
+                     do contains (in any order)
+                        ["a", "X"]
+                     but could not find elements:
+                        ["X"]
+                    """);
+    }
+
+    [TestCase(0, TestName = "Array")]
+    [TestCase(1, TestName = "List<object>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void ContainsSameOnObjects(int dataPointIndex)
+    {
+        var testData = TestDataPointObjectValues[dataPointIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
+        AssertArray(current).ContainsSame(obj1);
+        AssertArray(current).ContainsSame(obj2);
+        AssertArray(current).ContainsSame(obj2, obj3);
+        AssertArray(current).ContainsSame(obj1, obj2, obj3, obj4);
+        AssertArray(current).ContainsSame(obj4, obj1, obj3, obj2);
+        AssertArray(current).ContainsSame(current);
+        // should fail because the array not contains 'obj5'
+        AssertThrown(() => AssertArray(current).ContainsSame(obj1, obj5))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1047)
+            .HasMessage("""
+                    Expecting contains elements:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do contains (in any order)
+                        [$obj1, $obj5]
+                     but could not find elements:
+                        [$obj5]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
+    }
+
+    [TestCase(0, TestName = "Array")]
+    [TestCase(1, TestName = "List<string>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<string>")]
+    public void ContainsSameExactlyOnString(int dataPointIndex)
+    {
+        var testData = TestDataPointStringValues[dataPointIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
+        // test against only one element
+        AssertArray(current).ContainsSameExactly(obj1, obj2, obj3, obj4);
+        AssertArray(current).ContainsSameExactly(obj1, obj2, obj3, obj1); // for string obj1 is reference equals to obj4
+        AssertArray(current).ContainsSameExactly(current);
+        AssertThrown(() => AssertArray(current).ContainsSameExactly(obj1))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1083)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        ["a", "b", "c", "a"]
+                     do contains (in same order)
+                        ["a"]
+                     but others where not expected:
+                        ["b", "c", "a"]
+                    """);
+
+        AssertThrown(() => AssertArray(current).ContainsSameExactly(obj1, obj2))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1095)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        ["a", "b", "c", "a"]
+                     do contains (in same order)
+                        ["a", "b"]
+                     but others where not expected:
+                        ["c", "a"]
+                    """);
+        AssertThrown(() => AssertArray(current).ContainsSameExactly(obj1, obj5))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1106)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        ["a", "b", "c", "a"]
+                     do contains (in same order)
+                        ["a", "X"]
+                     but others where not expected:
+                        ["b", "c", "a"]
+                     and some elements not found:
+                        ["X"]
+                    """);
+    }
+
+    [TestCase(0, TestName = "Array<object>")]
+    [TestCase(1, TestName = "List<object>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void ContainsSameExactlyOnObjects(int testDataIndex)
+    {
+        var testData = TestDataPointObjectValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
+        // test against only one element
+        AssertArray(current).ContainsSameExactly(obj1, obj2, obj3, obj4);
+        AssertArray(current).ContainsSameExactly(current);
+        // when compare by reference equal obj1 != obj4
+        AssertThrown(() => AssertArray(current).ContainsSameExactly(obj1, obj2, obj3, obj1))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1139)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do contains (in same order)
+                        [$obj1, $obj2, $obj3, $obj1]
+                     but others where not expected:
+                        [$obj4]
+                     and some elements not found:
+                        [$obj1]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4)));
+        AssertThrown(() => AssertArray(current).ContainsSameExactly(obj1))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1156)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do contains (in same order)
+                        [$obj1]
+                     but others where not expected:
+                        [$obj2, $obj3, $obj4]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4)));
+        AssertThrown(() => AssertArray(current).ContainsSameExactly(obj1, obj2))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1171)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do contains (in same order)
+                        [$obj1, $obj2]
+                     but others where not expected:
+                        [$obj3, $obj4]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4)));
+        AssertThrown(() => AssertArray(current).ContainsSameExactly(obj1, obj5))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1186)
+            .HasMessage("""
+                    Expecting contains exactly elements:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do contains (in same order)
+                        [$obj1, $obj5]
+                     but others where not expected:
+                        [$obj2, $obj3, $obj4]
+                     and some elements not found:
+                        [$obj5]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
+    }
+
+    [TestCase(0, TestName = "Array<string>")]
+    [TestCase(1, TestName = "List<string>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<string>")]
+    public void NotContainsOnStrings(int testDataIndex)
+    {
+        var testData = TestDataPointStringValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
+        AssertArray(current).NotContains(obj5);
+        AssertArray(current).NotContains(obj5, obj5);
+        // we find `a` twice because is string equal
+        AssertThrown(() => AssertArray(current).NotContains(obj1))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1223)
+            .HasMessage("""
+                    Expecting:
+                        ["a", "b", "c", "a"]
+                     do NOT contains (in any order)
+                        ["a"]
+                     but found elements:
+                        ["a", "a"]
+                    """);
+        AssertThrown(() => AssertArray(current).NotContains(obj1, obj2, obj5))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1234)
+            .HasMessage("""
+                    Expecting:
+                        ["a", "b", "c", "a"]
+                     do NOT contains (in any order)
+                        ["a", "b", "X"]
+                     but found elements:
+                        ["a", "b", "a"]
+                    """);
+    }
+
+    [TestCase(0, TestName = "Array<object>")]
+    [TestCase(1, TestName = "List<object>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void NotContainsOnObject(int testDataIndex)
+    {
+        var testData = TestDataPointObjectValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
+        AssertArray(current).NotContains(obj5);
+        AssertArray(current).NotContains(obj5, obj5);
+        AssertThrown(() => AssertArray(current).NotContains(obj1))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1263)
+            .HasMessage("""
+                    Expecting:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do NOT contains (in any order)
+                        [$obj1]
+                     but found elements:
+                        [$obj1]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
+        AssertThrown(() => AssertArray(current).NotContains(obj1, obj2, obj5))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1279)
+            .HasMessage("""
+                    Expecting:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do NOT contains (in any order)
+                        [$obj1, $obj2, $obj5]
+                     but found elements:
+                        [$obj1, $obj2]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
+    }
+
+    [TestCase(0, TestName = "Array<string>")]
+    [TestCase(1, TestName = "List<string>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<string>")]
+    public void NotContainsSameOnStrings(int testDataIndex)
+    {
+        var testData = TestDataPointStringValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
+        AssertArray(current).NotContainsSame(obj5);
+        AssertArray(current).NotContainsSame(obj5, obj5);
+        // we find `a` twice because is string equal
+        AssertThrown(() => AssertArray(current).NotContainsSame(obj1))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1314)
+            .HasMessage("""
+                    Expecting:
+                        ["a", "b", "c", "a"]
+                     do NOT contains (in any order)
+                        ["a"]
+                     but found elements:
+                        ["a", "a"]
+                    """);
+        AssertThrown(() => AssertArray(current).NotContainsSame(obj1, obj2, obj5))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1325)
+            .HasMessage("""
+                    Expecting:
+                        ["a", "b", "c", "a"]
+                     do NOT contains (in any order)
+                        ["a", "b", "X"]
+                     but found elements:
+                        ["a", "b", "a"]
+                    """);
+    }
+
+    [TestCase(0, TestName = "Array<object>")]
+    [TestCase(1, TestName = "List<object>")]
+    [TestCase(2, TestName = "GodotArray")]
+    [TestCase(3, TestName = "GodotArray<RefCount>")]
+    public void NotContainsSameOnObject(int testDataIndex)
+    {
+        var testData = TestDataPointObjectValues[testDataIndex] as object[];
+        dynamic current = testData![0];
+        dynamic obj1 = current[0];
+        dynamic obj2 = current[1];
+        dynamic obj3 = current[2];
+        dynamic obj4 = current[3];
+        dynamic obj5 = testData![2];
+
+        AssertArray(current).NotContainsSame(obj5);
+        AssertArray(current).NotContainsSame(obj5, obj5);
+        AssertThrown(() => AssertArray(current).NotContainsSame(obj1))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1354)
+            .HasMessage("""
+                    Expecting:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do NOT contains (in any order)
+                        [$obj1]
+                     but found elements:
+                        [$obj1]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
+        AssertThrown(() => AssertArray(current).NotContainsSame(obj1, obj2, obj5))
+            .IsInstanceOf<TestFailedException>()
+            .HasFileLineNumber(1370)
+            .HasMessage("""
+                    Expecting:
+                        [$obj1, $obj2, $obj3, $obj4]
+                     do NOT contains (in any order)
+                        [$obj1, $obj2, $obj5]
+                     but found elements:
+                        [$obj1, $obj2]
+                    """
+                        .Replace("$obj1", AssertFailures.AsObjectId(obj1))
+                        .Replace("$obj2", AssertFailures.AsObjectId(obj2))
+                        .Replace("$obj3", AssertFailures.AsObjectId(obj3))
+                        .Replace("$obj4", AssertFailures.AsObjectId(obj4))
+                        .Replace("$obj5", AssertFailures.AsObjectId(obj5)));
+    }
+
+    // TODO: replace it by https://github.com/MikeSchulze/gdUnit4Mono/issues/46
+    public static readonly object[] TestDataPointEmptyArrays = new object[]{
+        Array.Empty<object>(),
+        new List<object>(),
+        new Godot.Collections.Array(),
+        new Godot.Collections.Array<RefCounted>()
+    };
+
+    public static readonly object[] TestDataPointStringValues = new object[]{
+        new object[]{
+            new string[] { "a", "b", "c", "a" },
+            new string[] { "a", "b", "c", "a" },
+            "X" },
+        new object[]{
+            new List<string>() { "a", "b", "c", "a" },
+            new List<string> { "a", "b", "c", "a" },
+            "X" },
+        new object[]{
+            new Godot.Collections.Array() { "a", "b", "c", "a" },
+            new Godot.Collections.Array { "a", "b", "c", "a" },
+            "X" },
+        new object[]{
+            new Godot.Collections.Array<string>() { "a", "b", "c", "a" },
+            new Godot.Collections.Array<string> { "a", "b", "c", "a" },
+            "X" },
+    };
+
+    public static readonly object[] TestDataPointObjectValues = new object[]{
+        new object[]{
+            new object[] { new(), new(), new(), new() },
+            new object[] { new(), new(), new(), new() },
+            new() },
+        new object[]{
+            new List<object>() { new(), new(), new(), new() },
+            new List<object>() { new(), new(), new(), new() },
+            new() },
+        new object[]{
+            new Godot.Collections.Array() { new RefCounted(), new RefCounted(), new RefCounted(), new RefCounted() },
+            new Godot.Collections.Array() { new RefCounted(), new RefCounted(), new RefCounted(), new RefCounted() },
+            new RefCounted() },
+        new object[]{
+            new Godot.Collections.Array<GodotObject>() { new RefCounted(), new RefCounted(), new RefCounted(), new RefCounted() },
+            new Godot.Collections.Array<GodotObject>() { new RefCounted(), new RefCounted(), new RefCounted(), new RefCounted() },
+            new RefCounted() }
+    };
 }

--- a/test/src/asserts/SignalAssertTest.cs
+++ b/test/src/asserts/SignalAssertTest.cs
@@ -57,7 +57,7 @@ public partial class SignalAssertTest
                 .IsInstanceOf<Exceptions.TestFailedException>()
                 .HasMessage("""
                     Expecting do emitting signal:
-                        "SignalC("abc", 101)"
+                        "SignalC(["abc", 101])"
                      by
                         $obj
                     """
@@ -78,7 +78,7 @@ public partial class SignalAssertTest
                 .IsInstanceOf<Exceptions.TestFailedException>()
                 .HasMessage("""
                     Expecting do NOT emitting signal:
-                        "visibility_changed()"
+                        "visibility_changed(<Empty>)"
                      by
                         $obj
                     """
@@ -102,7 +102,7 @@ public partial class SignalAssertTest
                .IsInstanceOf<Exceptions.TestFailedException>()
                .HasMessage("""
                     Expecting do emitting signal:
-                        "visibility_changed()"
+                        "visibility_changed(<Empty>)"
                      by
                         $obj
                     """

--- a/test/src/core/ExecutorTest.cs
+++ b/test/src/core/ExecutorTest.cs
@@ -85,16 +85,16 @@ public class ExecutorTest : ITestEventListener
         return expectedEvents;
     }
 
-    private IEnumerableAssert AssertTestCaseNames(List<TestEvent> events) =>
+    private IEnumerableAssert<object?> AssertTestCaseNames(List<TestEvent> events) =>
         AssertArray(events).ExtractV(Extr("Type"), Extr("SuiteName"), Extr("TestName"), Extr("TotalCount"));
 
-    private IEnumerableAssert AssertEventCounters(List<TestEvent> events) =>
+    private IEnumerableAssert<object?> AssertEventCounters(List<TestEvent> events) =>
         AssertArray(events).ExtractV(Extr("Type"), Extr("TestName"), Extr("ErrorCount"), Extr("FailedCount"), Extr("OrphanCount"));
 
-    private IEnumerableAssert AssertEventStates(List<TestEvent> events) =>
+    private IEnumerableAssert<object?> AssertEventStates(List<TestEvent> events) =>
          AssertArray(events).ExtractV(Extr("Type"), Extr("TestName"), Extr("IsSuccess"), Extr("IsWarning"), Extr("IsFailed"), Extr("IsError"));
 
-    private IEnumerableAssert AssertReports(List<TestEvent> events)
+    private IEnumerableAssert<object?> AssertReports(List<TestEvent> events)
     {
         var extractedEvents = events.ConvertAll(e =>
         {
@@ -121,7 +121,7 @@ public class ExecutorTest : ITestEventListener
     }
 
     private static string ParameterizedTestCaseName(string testName, object[] testCaseParam)
-        => $"{testName}.{testName}({testCaseParam.Formatted()})";
+        => TestCase.BuildTestCaseName(testName, testName, testCaseParam);
 
     [TestCase(Description = "Verifies the complete test suite ends with success and no failures are reported.")]
     public async Task ExecuteSuccess()

--- a/testadapter/src/GdUnit4TestDiscoverer.cs
+++ b/testadapter/src/GdUnit4TestDiscoverer.cs
@@ -2,7 +2,6 @@ namespace GdUnit4.TestAdapter;
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -41,9 +40,9 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
         var runConfiguration = XmlRunSettingsUtilities.GetRunConfigurationNode(discoveryContext.RunSettings?.SettingsXml);
         var gdUnitSettingsProvider = discoveryContext.RunSettings?.GetSettings(RunSettingsXmlNode) as GdUnit4SettingsProvider;
         var gdUnitSettings = gdUnitSettingsProvider?.Settings ?? new GdUnit4Settings();
-        var filteredAssemblys = FilterWithoutTestAdapter(sources);
+        var filteredAssembles = FilterWithoutTestAdapter(sources);
 
-        foreach (var assemblyPath in filteredAssemblys)
+        foreach (var assemblyPath in filteredAssembles)
         {
             logger.SendMessage(TestMessageLevel.Informational, $"Discover tests for assembly: {assemblyPath}");
 
@@ -76,14 +75,11 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
                             .Where(attr => attr != null && attr.Arguments?.Length != 0)
                             .Select(attr =>
                             {
-                                var saveCulture = Thread.CurrentThread.CurrentCulture;
-                                Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US", true);
-                                var paramaterizedTestName = $"{attr.TestName ?? mi.Name}({attr.Arguments.Formatted()})";
-                                Thread.CurrentThread.CurrentCulture = saveCulture;
+                                var parameterizedTestName = Executions.TestCase.BuildTestCaseName(mi.Name, attr);
                                 return new
                                 {
-                                    TestName = paramaterizedTestName,
-                                    FullyQualifiedName = $"{mi.DeclaringType}.{mi.Name}.{paramaterizedTestName}"
+                                    TestName = parameterizedTestName,
+                                    FullyQualifiedName = $"{mi.DeclaringType}.{parameterizedTestName}"
                                 };
                             })
                             .DefaultIfEmpty(new


### PR DESCRIPTION
# Why
The API differs between GDScript and C# and needs to be reconciled.
# What

- improve messages on `AssertFailures` to accept generic types
- fix formatting issues for `IEnumerables`
- fix test case name building by using `TestCase.BuildTestCaseName` discovered after fixing the `IEnumerables` formattings
- rebuild `IEnumerableAssert` to make it generic
  - ContainsSame ✅
  - ContainsSameExactly ✅
  - ContainsSameExactlyInAnyOrder ✅
  - IsNotSame ✅
  - IsSame ✅
  - NotContains ✅
  - NotContainsSame ✅