### PR TITLE
GD-32: Add missing `SimulateMouseMoveRelative` and `SimulateMouseMoveAbsolute` to `ISceneRunner `

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -25,8 +25,10 @@ jobs:
         godot-version: ['4.2', '4.2.1']
         godot-status: ['stable']
         include:
+          - godot-version: '4.2.2'
+            godot-status: 'rc2'
           - godot-version: '4.3'
-            godot-status: 'dev1'
+            godot-status: 'dev5'
 
 
     name: "CI on Godot 🐧 v${{ matrix.godot-version }}-${{ matrix.godot-status }}"

--- a/api/gdUnit4Api.csproj
+++ b/api/gdUnit4Api.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Title>gdUnit4Api</Title>
-    <Version>4.2.1</Version>
+    <Version>4.2.2-rc.1</Version>
     <Description>
       GdUnit4 API is the C# extention to enable GdUnit4 to run/write unit tests in C#.
     </Description>
@@ -33,7 +33,7 @@
     <IsPackable>true</IsPackable>
     <PackageProjectUrl>https://github.com/MikeSchulze/gdUnit4Mono</PackageProjectUrl>
     <PackageId>gdUnit4.api</PackageId>
-    <PackageVersion>4.2.1.1</PackageVersion>
+    <PackageVersion>4.2.2-rc.1</PackageVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>GdUnit4 API release candidate.</PackageReleaseNotes>

--- a/api/src/ISceneRunner.cs
+++ b/api/src/ISceneRunner.cs
@@ -70,12 +70,23 @@ public interface ISceneRunner : IDisposable
     ISceneRunner SimulateMouseMove(Vector2 position);
 
     /// <summary>
+    /// Simulates a mouse move to the absolute coordinates.
+    /// </summary>
+    /// <param name="position">The final position of the mouse.</param>
+    /// <param name="time">The time to move the mouse to the final position in seconds (default is 1 second).</param>
+    /// <param name="transitionType">Sets the type of transition used (default is Linear).</param>
+    /// <returns>SceneRunner</returns>
+    Task SimulateMouseMoveAbsolute(Vector2 position, double time = 1.0, Tween.TransitionType transitionType = Tween.TransitionType.Linear);
+
+
+    /// <summary>
     /// Simulates a mouse move to the relative coordinates (offset).
     /// </summary>
     /// <param name="relative">The relative position, e.g. the mouse position offset</param>
-    /// <param name="speed">The mouse speed in pixels per second.</param>
+    /// <param name="time">The time to move the mouse by the relative position in seconds (default is 1 second).</param>
+    /// <param name="transitionType">Sets the type of transition used (default is Linear).</param>
     /// <returns>SceneRunner</returns>
-    Task SimulateMouseMoveRelative(Vector2 relative, Vector2 speed = default);
+    Task SimulateMouseMoveRelative(Vector2 relative, double time = 1.0, Tween.TransitionType transitionType = Tween.TransitionType.Linear);
 
     /// <summary>
     /// Simulates a mouse button pressed.

--- a/example/exampleProject.csproj
+++ b/example/exampleProject.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftSdkVersion)" />
-    <PackageReference Include="gdUnit4.api" Version="4.2.1" />
-    <PackageReference Include="gdUnit4.test.adapter" Version="1.0.0" />
+    <PackageReference Include="gdUnit4.api" Version="4.2.*-*" />
+    <PackageReference Include="gdUnit4.test.adapter" Version="1.*-*" />
   </ItemGroup>
 </Project>

--- a/test/src/core/SceneRunnerInputEventIntegrationTest.cs
+++ b/test/src/core/SceneRunnerInputEventIntegrationTest.cs
@@ -354,17 +354,42 @@ public sealed class SceneRunnerInputEventIntegrationTest
         //verify(_scene_spy, 1)._input(mouseEvent)
     }
 
-    [TestCase(Timeout = 4000)]
+    [TestCase(Timeout = 2000)]
     public async Task SimulateMouseMoveRelative()
     {
-        sceneRunner.SimulateMouseMove(new Vector2(10, 10));
+        var sourcePosition = new Vector2(10, 10);
+        sceneRunner.SimulateMouseMove(sourcePosition);
         await ISceneRunner.SyncProcessFrame;
         // initial pos
-        AssertThat(ActualMousePos()).IsEqual(new Vector2(10, 10));
+        AssertThat(ActualMousePos()).IsEqual(sourcePosition);
 
-        await sceneRunner.SimulateMouseMoveRelative(new Vector2(900, 400), new Vector2(.2f, 1));
-        // final pos
+        // now move it from source position with offset, in 1s
+        await sceneRunner.SimulateMouseMoveRelative(new Vector2(900, 400));
+        // check relative position is reached
         AssertThat(ActualMousePos()).IsEqual(new Vector2(910, 410));
+
+        // and now move it back to source position, in 500ms
+        await sceneRunner.SimulateMouseMoveRelative(new Vector2(-900, -400), .5);
+        AssertThat(ActualMousePos()).IsEqual(sourcePosition);
+    }
+
+    [TestCase(Timeout = 2000)]
+    public async Task SimulateMouseMoveAbsolute()
+    {
+        var sourcePosition = new Vector2(10, 10);
+        sceneRunner.SimulateMouseMove(sourcePosition);
+        await ISceneRunner.SyncProcessFrame;
+        // initial pos
+        AssertThat(ActualMousePos()).IsEqual(sourcePosition);
+
+        // now move it to new position, in 1s
+        await sceneRunner.SimulateMouseMoveAbsolute(new Vector2(900, 400));
+        // check relative position is reached
+        AssertThat(ActualMousePos()).IsEqual(new Vector2(900, 400));
+
+        // and now move it back to source position, in 500ms
+        await sceneRunner.SimulateMouseMoveAbsolute(sourcePosition, .5);
+        AssertThat(ActualMousePos()).IsEqual(sourcePosition);
     }
 
     [TestCase]

--- a/testadapter/gdUnit4TestAdapter.csproj
+++ b/testadapter/gdUnit4TestAdapter.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Title>gdUnit4TestAdapter</Title>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Description>
       GdUnit4 Test Adapter is the test adapter to run GdUnit4 tests in C#.
     </Description>
@@ -33,7 +33,7 @@
     <IsPackable>true</IsPackable>
     <PackageProjectUrl>https://github.com/MikeSchulze/gdUnit4Mono</PackageProjectUrl>
     <PackageId>gdUnit4.test.adapter</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.0.1</PackageVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>GdUnit4 Test Adapter beta.</PackageReleaseNotes>
@@ -41,6 +41,8 @@
     <PackageTags>Godot;Test;Testing;UnitTest;GdUnit4;Utility;Utilities</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/MikeSchulze/gdUnit4Mono</RepositoryUrl>
+      <!-- ingnore dependency warnings to pre release version of gdunit.api -->
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Why
With https://github.com/MikeSchulze/gdUnit4/pull/329 we changed the method signature of `SimulateMouseMoveRelative` and introduced `SimulateMouseMoveAbsolute`

# What
- Implement the `SimulateMouseMoveRelative` and `SimulateMouseMoveAbsolute`
- set API version 4.2.2-rc.1
- fix NuGet package dependencies resolving to include pre releases
