### PR TITLE
GD-76: Fix `DisplayName` resolving on test adapter

### DIFF
--- a/api/src/core/GdUnitTestSuiteBuilder.cs
+++ b/api/src/core/GdUnitTestSuiteBuilder.cs
@@ -212,13 +212,15 @@ public class GdUnitTestSuiteBuilder
                 {
                     var lineNumber = TestCaseLineNumber(syntaxTree, mi.Name);
                     // collect testcase if multiple TestCaseAttribute exists
-                    var testCases = mi.GetCustomAttributes(typeof(TestCaseAttribute))
-                        .Cast<TestCaseAttribute>()
-                        .Where(attr => attr != null && attr.Arguments?.Length != 0)
+                    var attributes = mi.GetCustomAttributes(typeof(TestCaseAttribute))
+                            .Cast<TestCaseAttribute>();
+                    var testCases = attributes
+                        .Where(attr => attr.Arguments?.Length != 0)
                         .Select(attr => TestCase.BuildDisplayName(mi.Name, attr))
                         .ToList();
                     // create test
-                    return new CsNode(mi.Name, classPath, lineNumber, testCases);
+                    var testName = attributes.Count() == 1 ? attributes.First().TestName ?? mi.Name : mi.Name;
+                    return new CsNode(testName, classPath, lineNumber, testCases);
                 })
                 .Aggregate(new CsNode(classDefinition.Name, classPath), (acc, node) =>
                 {

--- a/api/src/core/execution/ExecutionContext.cs
+++ b/api/src/core/execution/ExecutionContext.cs
@@ -51,10 +51,10 @@ internal sealed class ExecutionContext : IDisposable
     public ExecutionContext(ExecutionContext context, TestCase testCase, TestCaseAttribute testCaseAttribute) : this(context.TestSuite, context.EventListeners, context.ReportOrphanNodesEnabled)
     {
         context.SubExecutionContexts.Add(this);
-        CurrentTestCase = testCase;
-        CurrentIteration = 0;
         TestCaseName = TestCase.BuildDisplayName(testCase.Name, testCaseAttribute);
         FullyQualifiedName = TestCase.BuildFullyQualifiedName(TestSuite.Instance.GetType().FullName!, testCase.Name, testCaseAttribute);
+        CurrentTestCase = testCase;
+        CurrentIteration = 0;
         IsSkipped = CurrentTestCase?.IsSkipped ?? false;
     }
 

--- a/api/src/core/execution/TestCase.cs
+++ b/api/src/core/execution/TestCase.cs
@@ -83,7 +83,7 @@ internal sealed class TestCase
 
     internal static string BuildFullyQualifiedName(string classNameSpace, string testName, TestCaseAttribute? attr)
     {
-        if (attr == null)
+        if (attr == null || attr.Arguments.Length == 0)
             return $"{classNameSpace}.{testName}";
         var parameterizedTestName = BuildDisplayName(testName, attr);
         return $"{classNameSpace}.{testName}.{parameterizedTestName}";

--- a/api/src/core/execution/TestSuite.cs
+++ b/api/src/core/execution/TestSuite.cs
@@ -9,8 +9,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 using GdUnit4.Core;
-using System.Threading;
-using System.Globalization;
 
 internal sealed class TestSuite : IDisposable
 {
@@ -65,15 +63,10 @@ internal sealed class TestSuite : IDisposable
     private Func<MethodInfo, bool> FilterByTestCaseName(IEnumerable<string>? includedTests, bool primitiveFilter)
         => mi =>
         {
-            var saveCulture = Thread.CurrentThread.CurrentCulture;
-            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US", true);
             var testCases = mi.GetCustomAttributes(typeof(TestCaseAttribute))
                 .Cast<TestCaseAttribute>()
-                .Where(attr => attr != null && attr.Arguments?.Length != 0)
-                .Select(attr => primitiveFilter ? mi.Name : TestCase.BuildDisplayName(mi.Name, attr))
-                .DefaultIfEmpty($"{mi.Name}")
+                .Select(attr => primitiveFilter ? mi.Name : TestCase.BuildFullyQualifiedName(mi.DeclaringType!.FullName!, mi.Name, attr))
                 .ToList();
-            Thread.CurrentThread.CurrentCulture = saveCulture;
             return includedTests?.Any(testName => testCases.Contains(testName)) ?? true;
         };
 

--- a/example/.runsettings
+++ b/example/.runsettings
@@ -33,6 +33,6 @@
         <Parameters></Parameters>
         <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
              This likely determines how the test names are displayed in the test results.-->
-        <DisplayName>SimpleName</DisplayName>
+        <DisplayName>FullyQualifiedName</DisplayName>
     </GdUnit4>
 </RunSettings>

--- a/example/.runsettings-ci
+++ b/example/.runsettings-ci
@@ -34,6 +34,6 @@
         <Parameters>--audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0</Parameters>
         <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
              This likely determines how the test names are displayed in the test results.-->
-        <DisplayName>SimpleName</DisplayName>
+        <DisplayName>FullyQualifiedName</DisplayName>
     </GdUnit4>
 </RunSettings>

--- a/test/.runsettings
+++ b/test/.runsettings
@@ -38,6 +38,6 @@
         <Parameters></Parameters>
         <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
              This likely determines how the test names are displayed in the test results.-->
-        <DisplayName>SimpleName</DisplayName>
+        <DisplayName>FullyQualifiedName</DisplayName>
     </GdUnit4>
 </RunSettings>

--- a/test/.runsettings-ci
+++ b/test/.runsettings-ci
@@ -51,6 +51,6 @@
         <Parameters>--audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --verbose</Parameters>
         <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
              This likely determines how the test names are displayed in the test results.-->
-        <DisplayName>SimpleName</DisplayName>
+        <DisplayName>FullyQualifiedName</DisplayName>
     </GdUnit4>
 </RunSettings>

--- a/test/src/core/ExampleTestSuite.cs
+++ b/test/src/core/ExampleTestSuite.cs
@@ -48,7 +48,7 @@ public class ExampleTestSuite
     public async Task Waiting()
         => await DoWait(200);
 
-    [TestCase]
+    [TestCase(TestName = "Customized")]
     public void TestFooBar()
         => AssertBool(true).IsEqual(true);
 

--- a/test/src/core/GdUnitTestSuiteBuilderTest.cs
+++ b/test/src/core/GdUnitTestSuiteBuilderTest.cs
@@ -228,7 +228,7 @@ public class GdUnitTestSuiteBuilderTest
                 Tuple("TestFoo", 36, new List<string>()),
                 Tuple("TestBar", 44, new List<string>()),
                 Tuple("Waiting", 48, new List<string>()),
-                Tuple("TestFooBar", 52, new List<string>()),
+                Tuple("Customized", 52, new List<string>()),
                 Tuple("TestCaseArguments", 58, new List<string> {
                     "TestCaseArguments(1, 2, 3, 6)",
                     "TestCaseArguments(3, 4, 5, 12)",

--- a/testadapter/src/GdUnit4TestDiscoverer.cs
+++ b/testadapter/src/GdUnit4TestDiscoverer.cs
@@ -83,28 +83,19 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
                         hierarchyValues[HierarchyConstants.Levels.ContainerIndex] = null;
                         hierarchyValues[HierarchyConstants.Levels.TestGroupIndex] = methodName;
                         var isAsync = MatchReturnType(mi, typeof(Task));
-                        // Collect parameterized tests or build a single test
+                        // Collect test cases or build a single test
                         mi.GetCustomAttributes(typeof(TestCaseAttribute))
                             .Cast<TestCaseAttribute>()
-                            .Where(attr => attr != null && attr.Arguments?.Length != 0)
-                            .Select(attr => new TestCaseDescriptor
+                            .Select((attr, index) => new TestCaseDescriptor
                             {
                                 ManagedType = managedType,
                                 ManagedMethod = managedMethod,
                                 HierarchyValues = new ReadOnlyCollection<string?>(hierarchyValues),
-                                DisplayName = Executions.TestCase.BuildDisplayName(mi.Name, attr),
+                                DisplayName = BuildDisplayName(mi.Name, index, attr, gdUnitSettings),
                                 FullyQualifiedName = Executions.TestCase.BuildFullyQualifiedName(managedType, mi.Name, attr),
                                 Traits = TestCasePropertiesAsTraits(mi)
                             })
-                            .DefaultIfEmpty(new TestCaseDescriptor
-                            {
-                                ManagedType = managedType,
-                                ManagedMethod = managedMethod,
-                                HierarchyValues = new ReadOnlyCollection<string?>(hierarchyValues),
-                                DisplayName = Executions.TestCase.BuildDisplayName(mi.Name),
-                                FullyQualifiedName = Executions.TestCase.BuildFullyQualifiedName(managedType, mi.Name, null)
-                            })
-                            .Select(testDescriptor => BuildTestCase(testDescriptor, assemblyPath, navData, gdUnitSettings))
+                            .Select(testDescriptor => BuildTestCase(testDescriptor, assemblyPath, navData))
                             .OrderBy(t => t.DisplayName)
                             .ToList()
                             .ForEach(t =>
@@ -125,24 +116,24 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
     private List<Trait> TestCasePropertiesAsTraits(MethodInfo mi)
         => mi.GetCustomAttributes(typeof(TestCaseAttribute))
                                     .Cast<TestCaseAttribute>()
-                                    .Where(attr => attr != null && attr.Arguments?.Length != 0)
+                                    .Where(attr => attr.Arguments?.Length != 0)
                                     .Select(attr => attr.Name == null
                                             ? new Trait(string.Empty, attr.Arguments.Formatted())
                                             : new Trait(attr.Name, attr.Arguments.Formatted())
                                     )
                                     .ToList();
 
-    private TestCase BuildTestCase(TestCaseDescriptor descriptor, string assemblyPath, CodeNavigation navData, GdUnit4Settings gdUnitSettings)
+    private TestCase BuildTestCase(TestCaseDescriptor descriptor, string assemblyPath, CodeNavigation navData)
     {
         TestCase testCase = new(descriptor.FullyQualifiedName, new Uri(GdUnit4TestExecutor.ExecutorUri), assemblyPath)
         {
             Id = GenerateTestId(descriptor, assemblyPath, navData),
-            DisplayName = BuildDisplayName(descriptor.DisplayName, descriptor.FullyQualifiedName, gdUnitSettings),
+            DisplayName = descriptor.DisplayName,
             FullyQualifiedName = descriptor.FullyQualifiedName,
             CodeFilePath = navData.Source,
             LineNumber = navData.Line
         };
-        testCase.SetPropertyValue(TestCaseNameProperty, testCase.DisplayName);
+        testCase.SetPropertyValue(TestCaseNameProperty, descriptor.FullyQualifiedName);
         testCase.SetPropertyValue(ManagedTypeProperty, descriptor.ManagedType);
         testCase.SetPropertyValue(ManagedMethodProperty, descriptor.ManagedMethod);
         if (descriptor.HierarchyValues?.Count > 0)
@@ -156,19 +147,27 @@ public sealed class GdUnit4TestDiscoverer : ITestDiscoverer
     {
         var idProvider = new TestIdProvider();
         idProvider.AppendString(assemblyPath);
+        idProvider.AppendString(descriptor.FullyQualifiedName);
         idProvider.AppendString(GdUnit4TestExecutor.ExecutorUri);
         idProvider.AppendString(navData.Source ?? "");
-        idProvider.AppendString(descriptor.FullyQualifiedName);
         return idProvider.GetId();
     }
 
-    private static string BuildDisplayName(string testName, string fullyQualifiedName, GdUnit4Settings gdUnitSettings) =>
-        gdUnitSettings.DisplayName switch
+    private static string BuildDisplayName(string testName, long index, TestCaseAttribute attr, GdUnit4Settings gdUnitSettings)
+        => gdUnitSettings.DisplayName switch
         {
-            DisplayNameOptions.SimpleName => testName,
-            DisplayNameOptions.FullyQualifiedName => fullyQualifiedName,
+            DisplayNameOptions.SimpleName => BuildSimpleDisplayName(testName, index, attr),
+            DisplayNameOptions.FullyQualifiedName => Executions.TestCase.BuildDisplayName(testName, attr),
             _ => testName
         };
+
+    private static string BuildSimpleDisplayName(string testName, long index, TestCaseAttribute attribute)
+    {
+        var displayName = attribute.TestName ?? testName;
+        if (index == -1 || attribute.Arguments.Length == 0)
+            return displayName;
+        return $"{displayName}'{index}";
+    }
 
     private static IEnumerable<string> FilterWithoutTestAdapter(IEnumerable<string> assemblyPaths) =>
         assemblyPaths.Where(assembly => !assembly.Contains(".TestAdapter."));

--- a/testadapter/src/execution/BaseTestExecutor.cs
+++ b/testadapter/src/execution/BaseTestExecutor.cs
@@ -47,7 +47,7 @@ internal abstract class BaseTestExecutor
         {
             Included = groupedTestSuites.ToDictionary(
                 suite => suite.Key,
-                suite => suite.Value.Select(t => new TestCaseConfig { Name = t.GetPropertyValue(TestCaseExtensions.TestCaseNameProperty, t.DisplayName) })
+                suite => suite.Value.Select(t => new TestCaseConfig { Name = t.GetPropertyValue(TestCaseExtensions.TestCaseNameProperty, t.FullyQualifiedName) })
             )
         };
 


### PR DESCRIPTION
# Why
The property `DisplayName` allows configuring between `SimpleName` and `FullyQualifiedName` but it runs into issues where the tests were not discovered or executed.

# What
- fixes the building of `DisplayName`:
  - do provide the full test name inclusive parameters when  `FullyQualifiedName`  is set
  - do provide the short test name exclusive parameters, but with index when  `SimpleName`  is set
- fix test filter to work on full qualified names
- simplify discover tests and fix the display name building
- fix custom name handling for single test cases (it was ignored)
- switch back to `FullyQualifiedName` on all `.runsettings`