### PR TITLE
GD-320: Fixing method chaining on Asserts breaks type inference after base interface methods

### DIFF
--- a/Api.Test/src/asserts/BoolAssertTest.cs
+++ b/Api.Test/src/asserts/BoolAssertTest.cs
@@ -126,4 +126,11 @@ public class BoolAssertTest
         // expect this line will never called because of the test is interrupted by a failing assert
         AssertBool(true).OverrideFailureMessage("This line should never be called").IsFalse();
     }
+
+    [TestCase]
+    public void MethodChainingBaseAssert()
+    {
+        AssertBool(true).IsNotNull().IsTrue();
+        AssertBool(true).IsTrue().IsNotNull();
+    }
 }

--- a/Api.Test/src/asserts/DictionaryAssertTest.cs
+++ b/Api.Test/src/asserts/DictionaryAssertTest.cs
@@ -723,4 +723,16 @@ public class DictionaryAssertTest
                             {"a1", 100}; {"a2", 200}
                         """);
     }
+
+    [TestCase]
+    [RequireGodotRuntime]
+    public void MethodChainingBaseAssert()
+    {
+        var dictionary = new Godot.Collections.Dictionary<string, string>
+        {
+            { "name", "Player" }
+        };
+        AssertThat(dictionary).IsNotNull().NotContainsKeys("A").ContainsKeys("name");
+        AssertThat(dictionary).NotContainsKeys("A").IsNotNull().ContainsKeys("name");
+    }
 }

--- a/Api.Test/src/asserts/EnumerableAssertTest.cs
+++ b/Api.Test/src/asserts/EnumerableAssertTest.cs
@@ -1709,6 +1709,21 @@ public partial class EnumerableAssertTest
                         custom data
                         """);
 
+    [TestCase]
+    [RequireGodotRuntime]
+    public void MethodChainingBaseAssert()
+    {
+        var array = new Godot.Collections.Array
+        {
+            1,
+            "hello",
+            3.14,
+            true
+        };
+        AssertThat(array).IsNotNull().Contains("hello").HasSize(4);
+        AssertThat(array).Contains("hello").IsNotNull().HasSize(4);
+    }
+
     // ReSharper disable once PartialTypeWithSinglePart
     // ReSharper disable MemberCanBePrivate.Local
     // ReSharper disable UnusedMember.Local

--- a/Api.Test/src/asserts/NumberAssertTest.cs
+++ b/Api.Test/src/asserts/NumberAssertTest.cs
@@ -440,4 +440,11 @@ public class NumberAssertTest
         // expect this line will never called because of the test is interrupted by a failing assert
         AssertBool(true).OverrideFailureMessage("This line should never be called").IsFalse();
     }
+
+    [TestCase]
+    public void MethodChainingBaseAssert()
+    {
+        AssertThat(42).IsNotNull().IsGreater(10).IsLess(50);
+        AssertThat(42).IsGreater(10).IsNotNull().IsLess(50);
+    }
 }

--- a/Api.Test/src/asserts/ObjectAssertTest.cs
+++ b/Api.Test/src/asserts/ObjectAssertTest.cs
@@ -344,4 +344,12 @@ public class ObjectAssertTest
         // expect this line will never called because of the test is interrupted by a failing assert
         AssertBool(true).OverrideFailureMessage("This line should never be called").IsFalse();
     }
+
+    [TestCase]
+    public void MethodChainingBaseAssert()
+    {
+        var obj = new object();
+        AssertObject(obj).IsNotNull().IsSame(obj).IsInstanceOf<object>();
+        AssertObject(obj).IsSame(obj).IsNotNull().IsInstanceOf<object>();
+    }
 }

--- a/Api.Test/src/asserts/SignalAssertTest.cs
+++ b/Api.Test/src/asserts/SignalAssertTest.cs
@@ -229,6 +229,14 @@ public partial class SignalAssertTest
                          """);
     }
 
+    [TestCase]
+    public void MethodChainingBaseAssert()
+    {
+        var emitter = AutoFree(new TimedEmitter { RunTime = 0.1f });
+        AssertSignal(emitter).IsNotNull().IsSignalExists("OnFinished");
+        AssertSignal(emitter).IsSignalExists("OnFinished").IsNotNull();
+    }
+
     private sealed partial class TestEmitter : Node
     {
         [Signal]

--- a/Api.Test/src/asserts/StringAssertTest.cs
+++ b/Api.Test/src/asserts/StringAssertTest.cs
@@ -465,4 +465,11 @@ public class StringAssertTest
         // expect this line will never called because of the test is interrupted by a failing assert
         AssertBool(true).OverrideFailureMessage("This line should never be called").IsFalse();
     }
+
+    [TestCase]
+    public void MethodChainingBaseAssert()
+    {
+        AssertObject("message").IsNotNull().IsEqual("message");
+        AssertObject("message").IsEqual("message").IsNotNull();
+    }
 }

--- a/Api.Test/src/asserts/VectorAssertTest.cs
+++ b/Api.Test/src/asserts/VectorAssertTest.cs
@@ -332,4 +332,12 @@ public class VectorAssertTest
                         Additional info:
                         custom data
                         """);
+
+    [TestCase]
+    [RequireGodotRuntime]
+    public void MethodChainingBaseAssert()
+    {
+        AssertThat(Vector3.Left).IsNotNull().IsEqual(Vector3.Left);
+        AssertThat(Vector3.Left).IsEqual(Vector3.Left).IsNotNull();
+    }
 }

--- a/Api/ReleaseNotes.txt
+++ b/Api/ReleaseNotes.txt
@@ -3,6 +3,7 @@ v5.0.1
 🪲 Bug Fixes
 * GD-311: Catch possible exceptions on command execution and report them as InternalServerError.
 * GD-305: Added missing AppendFailureMessage on assertions
+* GD-320: Fixing method Chaining on Asserts breaks type inference after base interface methods
 
 
 ✨ Improvements

--- a/Api/src/asserts/AssertBase.cs
+++ b/Api/src/asserts/AssertBase.cs
@@ -8,7 +8,7 @@ using CommandLine;
 using Core.Execution.Exceptions;
 using Core.Extensions;
 
-internal abstract class AssertBase<TValue, TAssert> : IAssertBase<TValue>, IAssertMessage<TAssert>
+internal abstract class AssertBase<TValue, TAssert> : IAssertBase<TValue, TAssert>, IAssertMessage<TAssert>
     where TAssert : IAssert
 {
     protected AssertBase(TValue? current) => Current = current;
@@ -21,34 +21,34 @@ internal abstract class AssertBase<TValue, TAssert> : IAssertBase<TValue>, IAsse
 
     protected string AppendingFailureMessage { get; set; } = string.Empty;
 
-    public IAssertBase<TValue> IsEqual(TValue expected)
+    public TAssert IsEqual(TValue expected)
     {
         var result = Comparable.IsEqual(Current, expected);
         if (!result.Valid)
             ThrowTestFailureReport(AssertFailures.IsEqual(Current, expected), Current, expected);
-        return this;
+        return this.Cast<TAssert>();
     }
 
-    public IAssertBase<TValue> IsNotEqual(TValue expected)
+    public TAssert IsNotEqual(TValue expected)
     {
         var result = Comparable.IsEqual(Current, expected);
         if (result.Valid)
             ThrowTestFailureReport(AssertFailures.IsNotEqual(Current, expected), Current, expected);
-        return this;
+        return this.Cast<TAssert>();
     }
 
-    public IAssertBase<TValue> IsNull()
+    public TAssert IsNull()
     {
         if (Current != null)
             ThrowTestFailureReport(AssertFailures.IsNull(Current), Current, null);
-        return this;
+        return this.Cast<TAssert>();
     }
 
-    public IAssertBase<TValue> IsNotNull()
+    public TAssert IsNotNull()
     {
         if (Current == null)
             ThrowTestFailureReport(AssertFailures.IsNotNull(), Current, null);
-        return this;
+        return this.Cast<TAssert>();
     }
 
     public TAssert OverrideFailureMessage(string message)

--- a/Api/src/asserts/IAssert.cs
+++ b/Api/src/asserts/IAssert.cs
@@ -22,37 +22,39 @@ public interface IAssert
 ///     Provides common assertion methods that apply to most value types.
 /// </summary>
 /// <typeparam name="TValue">The type of value being tested by this assertion.</typeparam>
+/// <typeparam name="TAssert">The type of used assertion.</typeparam>
 /// <remarks>
 ///     This generic interface extends the core IAssert interface with type-specific
 ///     assertion methods for comparing values and checking nullability.
 /// </remarks>
-public interface IAssertBase<in TValue> : IAssert
+public interface IAssertBase<in TValue, out TAssert> : IAssert
+    where TAssert : IAssert
 {
     /// <summary>
     ///     Verifies that the current value is null.
     /// </summary>
     /// <returns>IAssertBase.</returns>
-    IAssertBase<TValue> IsNull();
+    TAssert IsNull();
 
     /// <summary>
     ///     Verifies that the current value is not null.
     /// </summary>
     /// <returns>IAssertBase.</returns>
-    IAssertBase<TValue> IsNotNull();
+    TAssert IsNotNull();
 
     /// <summary>
     ///     Verifies that the current value is equal to the expected one.
     /// </summary>
     /// <param name="expected">The value to be equal.</param>
     /// <returns>IAssertBase.</returns>
-    IAssertBase<TValue> IsEqual(TValue expected);
+    TAssert IsEqual(TValue expected);
 
     /// <summary>
     ///     Verifies that the current value is not equal to the expected one.
     /// </summary>
     /// <param name="expected">The value to be NOT equal.</param>
     /// <returns>IAssertBase.</returns>
-    IAssertBase<TValue> IsNotEqual(TValue expected);
+    TAssert IsNotEqual(TValue expected);
 }
 
 /// <summary>

--- a/Api/src/asserts/VectorAssert.cs
+++ b/Api/src/asserts/VectorAssert.cs
@@ -31,8 +31,6 @@ internal sealed class VectorAssert<TValue> : AssertBase<TValue, IVectorConstrain
         return this;
     }
 
-    public new IVectorConstraint<TValue> IsEqual(TValue expected) => (IVectorConstraint<TValue>)base.IsEqual(expected);
-
     public IVectorConstraint<TValue> IsEqualApprox(TValue expected, TValue approx)
     {
         var (min, max) = MinMax(expected, approx);
@@ -89,8 +87,6 @@ internal sealed class VectorAssert<TValue> : AssertBase<TValue, IVectorConstrain
             ThrowTestFailureReport(AssertFailures.IsNotBetween(Current, min, max), Current, min);
         return this;
     }
-
-    public new IVectorConstraint<TValue> IsNotEqual(TValue expected) => (IVectorConstraint<TValue>)base.IsNotEqual(expected);
 
     private static int CompareTo(TValue? left, TValue right)
     {

--- a/Api/src/constraints/IBoolConstraint.cs
+++ b/Api/src/constraints/IBoolConstraint.cs
@@ -8,7 +8,7 @@ using Asserts;
 /// <summary>
 ///     A set of constrains to verify boolean values.
 /// </summary>
-public interface IBoolConstraint : IAssertBase<bool>
+public interface IBoolConstraint : IAssertBase<bool, IBoolConstraint>
 {
     /// <summary>
     ///     Verifies that the current value is true.

--- a/Api/src/constraints/IDictionaryConstraint.cs
+++ b/Api/src/constraints/IDictionaryConstraint.cs
@@ -13,7 +13,7 @@ using Asserts;
 /// </summary>
 /// <typeparam name="TKey">The type of keys in the dictionary.</typeparam>
 /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
-public interface IDictionaryConstraint<TKey, TValue> : IAssertBase<IEnumerable>
+public interface IDictionaryConstraint<TKey, TValue> : IAssertBase<IEnumerable, IDictionaryConstraint<TKey, TValue>>
     where TKey : notnull
 {
     /// <summary>
@@ -126,7 +126,7 @@ public interface IDictionaryConstraint<TKey, TValue> : IAssertBase<IEnumerable>
     ///     Verifies that the current dictionary is the same.
     /// </summary>
     /// <remarks>
-    ///     Compares the current by object reference equals, for deep parameter comparison use <see cref="IAssertBase{T}.IsEqual" />.
+    ///     Compares the current by object reference equals, for deep parameter comparison use <see cref="IAssertBase{TValue,TAssert}.IsEqual" />.
     /// </remarks>
     /// <param name="expected">The dictionary to be the same.</param>
     /// <returns>IDictionaryAssert for fluent method chaining.</returns>
@@ -136,7 +136,7 @@ public interface IDictionaryConstraint<TKey, TValue> : IAssertBase<IEnumerable>
     ///     Verifies that the current dictionary is the same as the given enumerable.
     /// </summary>
     /// <remarks>
-    ///     Compares the current by object reference equals, for deep parameter comparison use <see cref="IAssertBase{T}.IsEqual" />.
+    ///     Compares the current by object reference equals, for deep parameter comparison use <see cref="IAssertBase{TValue,TAssert}.IsEqual" />.
     /// </remarks>
     /// <param name="expected">The enumerable to be the same.</param>
     /// <returns>IDictionaryAssert for fluent method chaining.</returns>
@@ -146,7 +146,7 @@ public interface IDictionaryConstraint<TKey, TValue> : IAssertBase<IEnumerable>
     ///     Verifies that the current dictionary is NOT the same.
     /// </summary>
     /// <remarks>
-    ///     Compares the current by object reference equals, for deep parameter comparison use <see cref="IAssertBase{T}.IsNotEqual" />.
+    ///     Compares the current by object reference equals, for deep parameter comparison use <see cref="IAssertBase{TValue,TAssert}.IsNotEqual" />.
     /// </remarks>
     /// <param name="expected">The dictionary to be NOT the same.</param>
     /// <returns>IDictionaryAssert for fluent method chaining.</returns>
@@ -156,7 +156,7 @@ public interface IDictionaryConstraint<TKey, TValue> : IAssertBase<IEnumerable>
     ///     Verifies that the current dictionary is NOT the same as the given enumerable.
     /// </summary>
     /// <remarks>
-    ///     Compares the current by object reference equals, for deep parameter comparison use <see cref="IAssertBase{T}.IsNotEqual" />.
+    ///     Compares the current by object reference equals, for deep parameter comparison use <see cref="IAssertBase{TValue,TAssert}.IsNotEqual" />.
     /// </remarks>
     /// <param name="expected">The enumerable to be NOT the same.</param>
     /// <returns>IDictionaryAssert for fluent method chaining.</returns>

--- a/Api/src/constraints/IEnumerableConstraint.cs
+++ b/Api/src/constraints/IEnumerableConstraint.cs
@@ -11,7 +11,7 @@ using Godot.Collections;
 ///     A set of constrains to verify enumerating.
 /// </summary>
 /// <typeparam name="TValue">The type of elements in the enumerable being asserted.</typeparam>
-public interface IEnumerableConstraint<in TValue> : IAssertBase<IEnumerable<TValue?>>
+public interface IEnumerableConstraint<in TValue> : IAssertBase<IEnumerable<TValue?>, IEnumerableConstraint<TValue>>
 {
     /// <summary>
     ///     Verifies that the current enumerable is equal to the given one, ignoring case considerations.
@@ -43,7 +43,7 @@ public interface IEnumerableConstraint<in TValue> : IAssertBase<IEnumerable<TVal
     ///     Verifies that the current enumerable is the same.
     /// </summary>
     /// <remarks>
-    ///     Compares the current by object reference equals, for deep comparison use <see cref="IAssertBase{TValue}.IsEqual(TValue)" />.
+    ///     Compares the current by object reference equals, for deep comparison use <see cref="IAssertBase{TValue,TAssert}.IsEqual(TValue)" />.
     /// </remarks>
     /// <param name="expected">The value to be the same.</param>
     /// <returns>IEnumerableAssert.</returns>
@@ -53,7 +53,7 @@ public interface IEnumerableConstraint<in TValue> : IAssertBase<IEnumerable<TVal
     ///     Verifies that the current enumerable is NOT the same.
     /// </summary>
     /// <remarks>
-    ///     Compares the current by object reference equals, for deep comparison use <see cref="IAssertBase{TValue}.IsNotEqual(TValue)" />.
+    ///     Compares the current by object reference equals, for deep comparison use <see cref="IAssertBase{TValue,TAssert}.IsNotEqual(TValue)" />.
     /// </remarks>
     /// <param name="expected">The value to be NOT the same.</param>
     /// <returns>IEnumerableAssert.</returns>

--- a/Api/src/constraints/INumberConstraint.cs
+++ b/Api/src/constraints/INumberConstraint.cs
@@ -15,7 +15,7 @@ using Asserts;
 ///     The numeric type being tested. Must implement IComparable, IComparable{TValue}, IEquatable{TValue},
 ///     IAdditionOperators{TValue, TValue, TValue}, and ISubtractionOperators{TValue, TValue, TValue}.
 /// </typeparam>
-public interface INumberConstraint<in TValue> : IAssertBase<TValue>
+public interface INumberConstraint<in TValue> : IAssertBase<TValue, INumberConstraint<TValue>>
     where TValue : IComparable, IComparable<TValue>, IEquatable<TValue>,
     IAdditionOperators<TValue, TValue, TValue>, ISubtractionOperators<TValue, TValue, TValue>
 {

--- a/Api/src/constraints/IObjectConstraint.cs
+++ b/Api/src/constraints/IObjectConstraint.cs
@@ -8,7 +8,7 @@ using Asserts;
 /// <summary>
 ///     A set of constrains to verify object values.
 /// </summary>
-public interface IObjectConstraint : IAssertBase<object>
+public interface IObjectConstraint : IAssertBase<object, IObjectConstraint>
 {
     /// <summary>
     ///     Verifies that the current value is the same as the given one.

--- a/Api/src/constraints/ISignalConstraint.cs
+++ b/Api/src/constraints/ISignalConstraint.cs
@@ -10,7 +10,7 @@ using Godot;
 /// <summary>
 ///     A set of constrains to verify Godot signals.
 /// </summary>
-public interface ISignalConstraint : IAssertBase<GodotObject>, IGdUnitAwaitable
+public interface ISignalConstraint : IAssertBase<GodotObject, ISignalConstraint>, IGdUnitAwaitable
 {
     /// <summary>
     ///     Starts the monitoring of emitted signals during the test runtime.

--- a/Api/src/constraints/IStringConstraint.cs
+++ b/Api/src/constraints/IStringConstraint.cs
@@ -8,7 +8,7 @@ using Asserts;
 /// <summary>
 ///     A set of constrains to verify string values.
 /// </summary>
-public interface IStringConstraint : IAssertBase<string>
+public interface IStringConstraint : IAssertBase<string, IStringConstraint>
 {
     /// <summary>
     ///     Verifies that the current String is equal to the given one, ignoring case considerations.

--- a/Api/src/constraints/IVectorConstraint.cs
+++ b/Api/src/constraints/IVectorConstraint.cs
@@ -13,7 +13,7 @@ using Asserts;
 ///     The vector type being tested. Must implement IEquatable{TValue} to enable value comparisons.
 ///     Typically used with Godot.Vector2, Godot.Vector3, or Godot.Vector4 types.
 /// </typeparam>
-public interface IVectorConstraint<in TValue> : IAssertBase<TValue>
+public interface IVectorConstraint<in TValue> : IAssertBase<TValue, IVectorConstraint<TValue>>
     where TValue : IEquatable<TValue>
 {
     /// <summary>


### PR DESCRIPTION
# Why
When using fluent assertions, calling methods defined in IAssertBase (like IsNotNull()) before methods defined in IObjectConstraint (like IsSame()) causes the compiler to lose type information, resulting in generic type inference errors.

# What
- Extent `IAssertBase` interface by assert type to not break the method chain of actual assert type
- Apply the assert type to all assertions
- Add test coverage to verify the method changing works as expected.