### PR TITLE
GD-319: Fixing SceneRunner.Scene() returns disposed object after the scene is auto freed.

### DIFF
--- a/Api.Test/src/core/SceneRunnerCSharpSceneTest.cs
+++ b/Api.Test/src/core/SceneRunnerCSharpSceneTest.cs
@@ -95,7 +95,8 @@ public sealed class SceneRunnerCSharpSceneTest
             .IsInstanceOf<TestSceneWithInitialization>()
             .IsSame(currentScene);
 
-        var actualScene = (TestSceneWithInitialization)runner.Scene();
+        // ReSharper disable once NullableWarningSuppressionIsUsed
+        var actualScene = (runner.Scene() as TestSceneWithInitialization)!;
         AssertThat(actualScene.MethodCalls.Count).IsEqual(2);
         AssertThat(actualScene.MethodCalls[0]).IsEqual("Initialize");
         AssertThat(actualScene.MethodCalls[1]).IsEqual("_Ready");
@@ -352,26 +353,5 @@ public sealed class SceneRunnerCSharpSceneTest
         spell = sceneRunner.FindChild("Spell");
         // use global AwaitSignalOn
         await AwaitSignalOn(spell, Spell.SignalName.SpellExplode, spell.GetInstanceId()).WithTimeout(1100);
-    }
-
-    [TestCase]
-    public async Task DisposeSceneRunner()
-    {
-        var runner = ISceneRunner.Load("res://src/core/resources/scenes/TestSceneCSharp.tscn", true);
-        var tree = (SceneTree)Engine.GetMainLoop();
-
-        var currentScene = runner.Scene();
-        var nodePath = currentScene.GetPath();
-        // check scene is loaded and added to the root node
-        AssertThat(GodotObject.IsInstanceValid(currentScene)).IsTrue();
-        AssertThat(tree.Root.GetNodeOrNull(nodePath)).IsNotNull();
-
-        await ISceneRunner.SyncProcessFrame;
-        runner.Dispose();
-
-        await ISceneRunner.SyncProcessFrame;
-        // check scene is freed and removed from the root node
-        AssertThat(GodotObject.IsInstanceValid(currentScene)).IsFalse();
-        AssertThat(tree.Root.GetNodeOrNull(nodePath)).IsNull();
     }
 }

--- a/Api.Test/src/core/SceneRunnerGDScriptSceneTest.cs
+++ b/Api.Test/src/core/SceneRunnerGDScriptSceneTest.cs
@@ -271,25 +271,4 @@ public class SceneRunnerGDScriptSceneTest
         await sceneRunner.AwaitSignal("panel_color_change", box1, new Color(0, 0, 1)); // Blue
         await sceneRunner.AwaitSignal("panel_color_change", box1, new Color(0, 1, 0)); // Green
     }
-
-    [TestCase]
-    public async Task DisposeSceneRunner()
-    {
-        var sceneRunner_ = ISceneRunner.Load("res://src/core/resources/scenes/TestSceneGDScript.tscn", true);
-        var tree = (SceneTree)Engine.GetMainLoop();
-
-        var currentScene = sceneRunner_.Scene();
-        var nodePath = currentScene.GetPath();
-        // check scene is loaded and added to the root node
-        AssertThat(GodotObject.IsInstanceValid(currentScene)).IsTrue();
-        AssertThat(tree.Root.GetNodeOrNull(nodePath)).IsNotNull();
-
-        await ISceneRunner.SyncProcessFrame;
-        sceneRunner_.Dispose();
-
-        await ISceneRunner.SyncProcessFrame;
-        // check scene is freed and removed from the root node
-        AssertThat(GodotObject.IsInstanceValid(currentScene)).IsFalse();
-        AssertThat(tree.Root.GetNodeOrNull(nodePath)).IsNull();
-    }
 }

--- a/Api.Test/src/core/SceneRunnerInputEventIntegrationTest.cs
+++ b/Api.Test/src/core/SceneRunnerInputEventIntegrationTest.cs
@@ -57,7 +57,7 @@ public sealed class SceneRunnerInputEventIntegrationTest
         }
     }
 
-    private Vector2 ActualMousePos() => sceneRunner.Scene().GetViewport().GetMousePosition();
+    private Vector2 ActualMousePos() => sceneRunner.Scene()?.GetViewport().GetMousePosition() ?? Vector2.Inf;
 
     // [TestCase]
     public void TestSpy()
@@ -748,7 +748,8 @@ public sealed class SceneRunnerInputEventIntegrationTest
         //var spy_scene = spy("res://addons/gdUnit4/test/core/resources/scenes/drag_and_drop/DragAndDropTestScene.tscn")
         //var runner := scene_runner(spy_scene)
 
-        var scene = dragAndDropSceneRunner.Scene();
+        // ReSharper disable once NullableWarningSuppressionIsUsed
+        var scene = dragAndDropSceneRunner.Scene()!;
         var slot_left = scene.GetNode<TextureRect>(new NodePath("/root/DragAndDropScene/left/TextureRect"));
         var slot_right = scene.GetNode<TextureRect>(new NodePath("/root/DragAndDropScene/right/TextureRect"));
 

--- a/Api.Test/src/core/SceneRunnerLiveCycleTest.cs
+++ b/Api.Test/src/core/SceneRunnerLiveCycleTest.cs
@@ -1,0 +1,80 @@
+namespace GdUnit4.Tests.Core;
+
+using System.Threading.Tasks;
+
+using Godot;
+
+using static Assertions;
+
+[RequireGodotRuntime]
+[TestSuite]
+public sealed class SceneRunnerLiveCycleTest
+{
+#nullable disable
+    private ISceneRunner sceneRunner;
+#nullable enable
+
+    [Before]
+    public void Setup() => AssertThat(sceneRunner).IsNull();
+
+    [After]
+    public void TearDown()
+    {
+        AssertThat(sceneRunner).IsNotNull();
+        AssertThat(sceneRunner.Scene()).IsNull();
+    }
+
+    [BeforeTest]
+    public void BeforeTest()
+    {
+        sceneRunner = ISceneRunner.Load("res://src/core/resources/scenes/TestSceneCSharp.tscn", true);
+        AssertThat(sceneRunner).IsNotNull();
+        AssertThat(sceneRunner.Scene()).IsNotNull();
+    }
+
+    [AfterTest]
+    public void AfterTest()
+    {
+        AssertThat(sceneRunner).IsNotNull();
+        AssertThat(sceneRunner.Scene()).IsNotNull();
+    }
+
+    [TestCase]
+    public void LoadAdditionalScene()
+    {
+        using var runner = ISceneRunner.Load("uid://cn8ucy2rheu0f", true);
+        AssertThat(runner.Scene())
+            .IsInstanceOf<Node2D>()
+            .IsNotNull();
+
+        // verify scene is still valid
+        AssertThat(sceneRunner.Scene()).IsNotNull();
+        // verify it fails when try to load a scene using null argument
+#pragma warning disable CS8625, CS8600 // Converting null literal or possible null value to non-nullable type.
+        AssertThrown(() => ISceneRunner.Load((Node)null, true))
+            .HasMessage("SceneRunner requires a valid scene instance, but received null");
+#pragma warning restore CS8625, CS8600 // Converting null literal or possible null value to non-nullable type.
+    }
+
+    [TestCase]
+    public async Task DisposeSceneRunner()
+    {
+        var runner = ISceneRunner.Load("res://src/core/resources/scenes/TestSceneCSharp.tscn", true);
+        var tree = (SceneTree)Engine.GetMainLoop();
+
+        var currentScene = runner.Scene();
+        var nodePath = currentScene?.GetPath();
+        // check scene is loaded and added to the root node
+        AssertThat(GodotObject.IsInstanceValid(currentScene)).IsTrue();
+        AssertThat(tree.Root.GetNodeOrNull(nodePath)).IsNotNull();
+
+        await ISceneRunner.SyncProcessFrame;
+        runner.Dispose();
+
+        await ISceneRunner.SyncProcessFrame;
+        // check scene is freed and removed from the root node
+        AssertThat(GodotObject.IsInstanceValid(currentScene)).IsFalse();
+        AssertThat(tree.Root.GetNodeOrNull(nodePath)).IsNull();
+        AssertThat(runner.Scene()).IsNull();
+    }
+}

--- a/Api/ReleaseNotes.txt
+++ b/Api/ReleaseNotes.txt
@@ -4,6 +4,7 @@ v5.0.1
 * GD-311: Catch possible exceptions on command execution and report them as InternalServerError.
 * GD-305: Added missing AppendFailureMessage on assertions
 * GD-320: Fixing method Chaining on Asserts breaks type inference after base interface methods
+* GD-319: Fixing SceneRunner.Scene() returns disposed object after the scene is auto freed.
 
 
 ✨ Improvements

--- a/Api/src/ISceneRunner.cs
+++ b/Api/src/ISceneRunner.cs
@@ -293,7 +293,7 @@ public interface ISceneRunner : IDisposable
     /// </returns>
     async Task AwaitInputProcessed()
     {
-        if (Scene().ProcessMode != Node.ProcessModeEnum.Disabled)
+        if (Scene()?.ProcessMode != Node.ProcessModeEnum.Disabled)
             Input.FlushBufferedEvents();
 
         _ = await SyncProcessFrame;
@@ -302,9 +302,25 @@ public interface ISceneRunner : IDisposable
 
     /// <summary>
     ///     Access to the current running scene.
+    ///     Returns the scene instance that is currently loaded and managed by this SceneRunner.
+    ///     The scene remains available for testing and interaction until the runner is disposed
+    ///     or the scene is explicitly freed.<br />
+    ///     <br />
+    ///     Lifecycle behavior:<br />
+    ///     - Returns valid Node instance when scene is loaded and active<br />
+    ///     - Returns null when the SceneRunner has been disposed<br />
+    ///     - Returns null when autoFree has cleaned up the scene<br />
+    ///     <br />
+    ///     Usage patterns:<br />
+    ///     - Check for null before accessing scene properties or methods<br />
+    ///     - Use in assertions to verify scene state and availability<br />
+    ///     - Access child nodes through the returned scene instance.<br />
     /// </summary>
-    /// <returns>Node.</returns>
-    Node Scene();
+    /// <returns>
+    ///     The current scene Node instance, or null when the SceneRunner is disposed
+    ///     or the scene has been freed.
+    /// </returns>
+    Node? Scene();
 
     /// <summary>
     ///     Shows the running scene and moves the window to the foreground.

--- a/Api/src/core/MouseMoveTask.cs
+++ b/Api/src/core/MouseMoveTask.cs
@@ -6,6 +6,8 @@ using System.Diagnostics.CodeAnalysis;
 
 using Godot;
 
+using static Assertions;
+
 /// <summary>
 ///     A helper to simulate a mouse moving from a source to the final position.
 /// </summary>
@@ -34,7 +36,10 @@ internal partial class MouseMoveTask : Node, IDisposable
         Justification = "Method called for side effects only, return value intentionally ignored")]
     public async Task WaitOnFinalPosition(ISceneRunner sceneRunner, double time, Tween.TransitionType transitionType)
     {
-        using var tween = sceneRunner.Scene().CreateTween();
+        AssertObject(sceneRunner.Scene()).OverrideFailureMessage("No valid scene is loaded.").IsNotNull();
+
+        // ReSharper disable once NullableWarningSuppressionIsUsed
+        using var tween = sceneRunner.Scene()!.CreateTween();
         tween.TweenProperty(this, "CurrentMousePosition", FinalMousePosition, time).SetTrans(transitionType);
         tween.Play();
 

--- a/Api/src/core/SceneRunner.cs
+++ b/Api/src/core/SceneRunner.cs
@@ -33,6 +33,9 @@ internal sealed class SceneRunner : ISceneRunner
 
     public SceneRunner(Node currentScene, bool autoFree = false, bool verbose = false)
     {
+        AssertThat(currentScene)
+            .OverrideFailureMessage("SceneRunner requires a valid scene instance, but received null")
+            .IsNotNull();
         Verbose = verbose;
         SceneAutoFree = autoFree;
         ExecutionContext.RegisterDisposable(this);
@@ -236,7 +239,8 @@ internal sealed class SceneRunner : ISceneRunner
             _ = await ISceneRunner.SyncProcessFrame;
     }
 
-    public Node Scene() => currentScene;
+    public Node? Scene()
+        => IsDisposed ? null : currentScene;
 
     public IGodotMethodAwaitable<TVariant> AwaitMethod<[MustBeVariant] TVariant>(string methodName)
         where TVariant : notnull

--- a/GdUnit4Net.sln.DotSettings
+++ b/GdUnit4Net.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeEditing/SuppressNullableWarningFix/Enabled/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
# Why
During writing test examples, I see accessing the scene from scene runner after releasing returns a disposed object. When the scene runner is loading the scene using flag `autoFree` = true, it should return NULL after releasing.

# What
- Changed the method signature to allow returning null values on `Scene()`
- Return null if the scene runner disposed
- Add lifecycle integration test for the runner