### PR TITLE
GD-317: Fixing [IgnoreUntil] is not skipping the test.

### DIFF
--- a/Api.Test/src/core/ExampleTestSuite.cs
+++ b/Api.Test/src/core/ExampleTestSuite.cs
@@ -1,6 +1,5 @@
 namespace GdUnit4.Tests.Core;
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -77,11 +76,26 @@ public sealed class ExampleTestSuite
     public void ParameterizedSingleTest(bool value)
         => AssertThat(value).IsTrue();
 
+    [TestCase]
+    [IgnoreUntil(Until = "2030-08-23 22:56:00", Description = "Ignored until Aug 23, 2030 22:56 local time")]
+    public void SkippedUntilLocalDate()
+        => AssertBool(false)
+            .OverrideFailureMessage("Should never be called before Aug 23, 2030 22:56 local time")
+            .IsTrue();
 
     [TestCase]
-    [IgnoreUntil(Description = "This is an example of ignored test")]
-    public void SkippedTestCase()
-        => Console.WriteLine("SkippedTestCase");
+    [IgnoreUntil(UntilUtc = "2030-08-23 20:56:00", Description = "Ignored until Aug 23, 2030 20:56 UTC (22:56 CEST)")]
+    public void SkippedUntilUtcDate()
+        => AssertBool(false)
+            .OverrideFailureMessage("Should never be called before Aug 23, 2030 20:56 UTC")
+            .IsTrue();
+
+    [TestCase]
+    [IgnoreUntil(Description = "Permanently ignored until attribute is removed")]
+    public void Skipped()
+        => AssertBool(false)
+            .OverrideFailureMessage("Should never be called, this test is skipped")
+            .IsTrue();
 
     [TestCase]
     [DataPoint(nameof(TestDataProvider.GetTestData), typeof(TestDataProvider))]

--- a/Api.Test/src/core/discovery/TestCaseDiscovererTest.cs
+++ b/Api.Test/src/core/discovery/TestCaseDiscovererTest.cs
@@ -283,7 +283,7 @@ public class TestCaseDiscovererTest
 
         var tests = TestCaseDiscoverer.DiscoverTestCasesFromScript(script);
         AssertArray(tests)
-            .HasSize(13)
+            .HasSize(15)
             // Verify just exemplar for certain tests
             .Contains(new TestCaseDescriptor
             {
@@ -292,8 +292,8 @@ public class TestCaseDiscovererTest
                 AssemblyPath = assemblyPath,
                 ManagedType = "GdUnit4.Tests.Core.ExampleTestSuite",
                 ManagedMethod = "TestFoo",
-                Id = tests[9].Id,
-                LineNumber = 42,
+                Id = tests[11].Id,
+                LineNumber = 41,
                 CodeFilePath = codeFilePath,
                 AttributeIndex = 0,
                 RequireRunningGodotEngine = false,
@@ -306,8 +306,8 @@ public class TestCaseDiscovererTest
                 AssemblyPath = assemblyPath,
                 ManagedType = "GdUnit4.Tests.Core.ExampleTestSuite",
                 ManagedMethod = "TestCaseArguments",
-                Id = tests[3].Id,
-                LineNumber = 64,
+                Id = tests[5].Id,
+                LineNumber = 63,
                 CodeFilePath = codeFilePath,
                 AttributeIndex = 0,
                 RequireRunningGodotEngine = false
@@ -318,8 +318,8 @@ public class TestCaseDiscovererTest
                 AssemblyPath = assemblyPath,
                 ManagedType = "GdUnit4.Tests.Core.ExampleTestSuite",
                 ManagedMethod = "TestCaseArguments",
-                Id = tests[4].Id,
-                LineNumber = 64,
+                Id = tests[6].Id,
+                LineNumber = 63,
                 CodeFilePath = codeFilePath,
                 AttributeIndex = 1,
                 RequireRunningGodotEngine = false

--- a/Api/ReleaseNotes.txt
+++ b/Api/ReleaseNotes.txt
@@ -1,11 +1,11 @@
 v5.0.1
 
 🪲 Bug Fixes
-* GD-311: Catch possible exceptions on command execution and report them as InternalServerError.
 * GD-305: Added missing AppendFailureMessage on assertions
-* GD-320: Fixing method Chaining on Asserts breaks type inference after base interface methods
+* GD-311: Catch possible exceptions on command execution and report them as InternalServerError.
+* GD-317: Fixing [IgnoreUntil] is not skipping the test.
 * GD-319: Fixing SceneRunner.Scene() returns disposed object after the scene is auto freed.
-
+* GD-320: Fixing method Chaining on Asserts breaks type inference after base interface methods
 
 ✨ Improvements
 * GD-311: Verify the Godot binary has C# support before running godot runtime tests to avoid invalid test execution.

--- a/Api/src/core/execution/TestCase.cs
+++ b/Api/src/core/execution/TestCase.cs
@@ -33,7 +33,7 @@ internal sealed class TestCase
 
     public object?[] Arguments => IsParameterized ? TestCaseAttribute.Arguments : [.. Parameters.SelectMany(ResolveParam)];
 
-    public bool IsSkipped => Attribute.IsDefined(MethodInfo, typeof(IgnoreUntilAttribute));
+    public bool IsSkipped => IgnoreUntilAttribute.IsSkipped(MethodInfo);
 
     public bool IsParameterized => TestCaseAttributes.Any(p => p.Arguments.Length > 0);
 

--- a/Api/src/core/execution/TestSuiteExecutionStage.cs
+++ b/Api/src/core/execution/TestSuiteExecutionStage.cs
@@ -3,10 +3,7 @@
 
 namespace GdUnit4.Core.Execution;
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading.Tasks;
 
 using Data;
 
@@ -145,10 +142,13 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
                 .Execute(executionContext)
                 .ConfigureAwait(true);
 
-            using ExecutionContext context = new(executionContext, methodArguments);
-            await new TestCaseExecutionStage(context.TestCaseName, testCase, stageAttribute)
-                .Execute(context)
-                .ConfigureAwait(true);
+            if (!executionContext.IsSkipped)
+            {
+                using ExecutionContext context = new(executionContext, methodArguments);
+                await new TestCaseExecutionStage(context.TestCaseName, testCase, stageAttribute)
+                    .Execute(context)
+                    .ConfigureAwait(true);
+            }
         }
         finally
         {


### PR DESCRIPTION
# Why
I want to temporarily skip a test by using the test attribute [IgnoreUntil] but the test is still executed. It provides to define a description, but it misses a way to define an until condition.

# What
- Improved the IgnoreUntilAttribute by parameters `Until` and `UntilUtc` to specify when tests should stop being ignored
- Added `Until` property for local time-based test ignoring
- Added `UntilUtc` property for UTC time-based test ignoring
- Fixed missing skip condition check in `TestSuiteExecutionStage` to properly skip ignored tests