### PR TITLE
GD-358: Fixes broken `ThrowsException`

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -27,12 +27,12 @@ jobs:
         godot-version: ['4.3', '4.4', '4.4.1']
         godot-status: ['stable']
         dotnet-version: ['net9.0']
-        #include:
-        #  # Latest
-        #  - version: 'latest'
-        #    godot-version: '4.5'
-        #    godot-status: 'stable'
-        #    dotnet-version: 'net9.0'
+        include:
+          # Latest
+          - version: 'latest'
+            godot-version: '4.5'
+            godot-status: 'stable'
+            dotnet-version: 'net9.0'
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -202,12 +202,12 @@ jobs:
         godot-version: ['4.3', '4.4', '4.4.1']
         godot-status: ['stable']
         dotnet-version: ['net9.0']
-        #include:
-        #  # Latest
-        #  - gdunit-version: 'latest'
-        #    godot-version: '4.5'
-        #    godot-status: 'stable'
-        #    dotnet-version: 'net9.0'
+        include:
+          # Latest
+          - gdunit-version: 'latest'
+            godot-version: '4.5'
+            godot-status: 'stable'
+            dotnet-version: 'net9.0'
 
 
     name: "🧪 Test: API on Godot-v${{ matrix.godot-version }}-${{ matrix.godot-status }}"

--- a/Api/src/core/execution/monitoring/ErrorLogEntry.cs
+++ b/Api/src/core/execution/monitoring/ErrorLogEntry.cs
@@ -3,9 +3,6 @@
 
 namespace GdUnit4.Core.Execution.Monitoring;
 
-using System;
-using System.Collections.Generic;
-
 using Godot;
 
 internal sealed class ErrorLogEntry
@@ -94,7 +91,12 @@ internal sealed class ErrorLogEntry
             return null;
 
         // Remove the pattern and trim whitespace
-        var content = record.Replace(pattern, string.Empty, StringComparison.Ordinal).Trim();
+        var content = record.Replace(pattern, string.Empty, StringComparison.Ordinal)
+            .Trim()
+
+            // On Godot version before 4.5 the exception is covered by single quotes, we need to remove it to match!
+            .TrimStart('\'')
+            .TrimEnd('\'');
 
         // Get the details from the next line if available
         var details = index + 1 < records.Length ? records[index + 1].Trim() : string.Empty;

--- a/Api/src/core/execution/monitoring/GodotExceptionPattern.cs
+++ b/Api/src/core/execution/monitoring/GodotExceptionPattern.cs
@@ -12,7 +12,7 @@ internal static partial class GodotExceptionPattern
     public static Match ReleaseMode(string value)
         => ExceptionPatternRelease().Match(value);
 
-    [GeneratedRegex(@"'([\w\.]+Exception):\s*(.*)'", RegexOptions.Compiled)]
+    [GeneratedRegex(@"([\w\.]+Exception):\s*(.*)", RegexOptions.Compiled)]
     private static partial Regex ExceptionPatternDebug();
 
     [GeneratedRegex(@"([\w\.]+Exception):\s*(.*?)(?:\r\n|\n|$)", RegexOptions.Compiled)]


### PR DESCRIPTION
# Why
Running tests using `ThrowsException` with Godot 4.5 is broken,
Exception logging has changed in Godot 4.5. Previously, exceptions were enclosed in single quotation marks.
e.g.
'System.NullReferenceException: Nope'


# What
- removed the expectation of start/end single quote from the exception regex pattern and trim possible single quotes before using the regex to support old and new exception pattern