### PR TITLE
GD-366 Fixing race condition in Godot C# support detection

### DIFF
--- a/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
+++ b/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
@@ -165,6 +165,22 @@ public class GodotRuntimeTestRunnerTest
         AssertThat(File.Exists(runnerPath)).OverrideFailureMessage("Runner file should be cleaned up after timeout").IsFalse();
     }
 
+    [TestCase]
+    public void VerifyGodotCSharpSupport()
+    {
+        // Create a separate temp working directory
+        var workingDirectory = Path.Combine(TestTempDirectory!, "working_dir_timeout");
+        Directory.CreateDirectory(workingDirectory);
+
+        // Act
+        var godotPath = Environment.GetEnvironmentVariable("GODOT_BIN");
+        AssertThat(File.Exists(godotPath)).IsTrue();
+        var result = CreateTestRunner(1000).VerifyGodotCSharpSupport(godotPath!);
+
+        // Assert
+        AssertThat(result).OverrideFailureMessage("VerifyGodotCSharpSupport should succeed").IsTrue();
+    }
+
     /// <summary>
     ///     Test compilation failure scenario
     /// </summary>

--- a/ProjectVersions.props
+++ b/ProjectVersions.props
@@ -2,7 +2,7 @@
   <!-- GdUnit4 Component Versions -->
   <PropertyGroup>
     <GdUnitAnalyzersVersion>1.0.0</GdUnitAnalyzersVersion>
-    <GdUnitAPIVersion>5.1.0-rc2</GdUnitAPIVersion>
+    <GdUnitAPIVersion>5.1.0-rc3</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>3.0.1</GdUnitTestAdapterVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
# Why
The verification of Godot's C# support was unreliable due to a race condition between process termination and async output event processing. WaitForExit() could return before all OutputDataReceived events were processed, causing the check to run against incomplete output and incorrectly report missing C# support.

# What
- Add ManualResetEventSlim to track when output stream ends (args.Data == null)
- Wait for both process exit AND output completion before checking results
- Ensure all async output events are processed before evaluating --build-solutions flag

This eliminates false negatives where a valid Mono-enabled Godot binary would be incorrectly identified as lacking C# support due to incomplete output parsing.