### PR TITLE
GD-400: Add `ExtendWith<T>` attribute

### DIFF
--- a/Api/src/core/attributes/ExtendWithAttribute.cs
+++ b/Api/src/core/attributes/ExtendWithAttribute.cs
@@ -22,7 +22,6 @@ using Api;
 /// public class SomeTestSuite
 /// {
 ///   [TestCase]
-///   [ExtendWith&lt;SomeOtherExtension&gt;]
 ///   public void SomeTestCase()
 ///   {
 ///   }

--- a/Api/src/core/attributes/ExtendWithAttribute.cs
+++ b/Api/src/core/attributes/ExtendWithAttribute.cs
@@ -11,6 +11,9 @@ using Api;
 /// Extends the test suite or test method with the specified test extension, hooking it into the test lifecycle
 /// and enabling its callbacks and parameter injection for the annotated class or method.
 ///
+/// Note that extensions registered using this attribute <i>must</i> have a no-argument constructor or the test
+/// framework will be unable to instantiate them.
+///
 /// Usage:
 ///
 /// <code>
@@ -19,7 +22,7 @@ using Api;
 /// public class SomeTestSuite
 /// {
 ///   [TestCase]
-///   [ExtendWith&lt;SomeOtherTest&gt;]
+///   [ExtendWith&lt;SomeOtherExtension&gt;]
 ///   public void SomeTestCase()
 ///   {
 ///   }

--- a/Api/src/core/attributes/ExtendWithAttribute.cs
+++ b/Api/src/core/attributes/ExtendWithAttribute.cs
@@ -18,7 +18,7 @@ using Api;
 ///
 /// <code>
 /// [TestSuite]
-/// [ExtendWith&lt;SomeExtension&gt;]
+/// [ExtendWith<SomeExtension>]
 /// public class SomeTestSuite
 /// {
 ///   [TestCase]

--- a/Api/src/core/attributes/ExtendWithAttribute.cs
+++ b/Api/src/core/attributes/ExtendWithAttribute.cs
@@ -18,7 +18,7 @@ using Api;
 ///
 /// <code>
 /// [TestSuite]
-/// [ExtendWith<SomeExtension>]
+/// [ExtendWith&lt;SomeExtension&gt;]
 /// public class SomeTestSuite
 /// {
 ///   [TestCase]

--- a/Api/src/core/attributes/ExtendWithAttribute.cs
+++ b/Api/src/core/attributes/ExtendWithAttribute.cs
@@ -14,6 +14,7 @@ using Api;
 /// Usage:
 ///
 /// <code>
+/// [TestSuite]
 /// [ExtendWith&lt;SomeExtension&gt;]
 /// public class SomeTestSuite
 /// {

--- a/Api/src/core/attributes/ExtendWithAttribute.cs
+++ b/Api/src/core/attributes/ExtendWithAttribute.cs
@@ -10,6 +10,22 @@ using Api;
 /// <summary>
 /// Extends the test suite or test method with the specified test extension, hooking it into the test lifecycle
 /// and enabling its callbacks and parameter injection for the annotated class or method.
+///
+/// Usage:
+///
+/// <code>
+/// [ExtendWith&lt;SomeExtension&gt;]
+/// public class SomeTestSuite
+/// {
+///   [TestCase]
+///   [ExtendWith&lt;SomeOtherTest&gt;]
+///   public void SomeTestCase()
+///   {
+///   }
+/// }
+/// </code>
+///
+/// As demonstrated, this attribute can be applied to either test cases or suites.
 /// </summary>
 /// <typeparam name="T">The type of the extension to register.</typeparam>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]

--- a/Api/src/core/attributes/ExtendWithAttribute.cs
+++ b/Api/src/core/attributes/ExtendWithAttribute.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+// ReSharper disable once CheckNamespace
+// Need to be placed in the root namespace to be accessible by the test runner.
+namespace GdUnit4;
+
+using Api;
+
+/// <summary>
+/// Extends the test suite or test method with the specified test extension, hooking it into the test lifecycle
+/// and enabling its callbacks and parameter injection for the annotated class or method.
+/// </summary>
+/// <typeparam name="T">The type of the extension to register.</typeparam>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+public sealed class ExtendWithAttribute<T> : Attribute
+    where T : ITestExtension, new();


### PR DESCRIPTION
# Why

This attribute will be used to register extensions at the class (suite) and method (test case) levels.

# What

`ExtendWithAttribute<T>` will be usable on either classes or methods, and will register extensions that do not have constructor arguments.