### PR TITLE
GD-400: Implement `IParameterContext`

### DIFF
--- a/Api/src/core/testExtensions/ParameterContext.cs
+++ b/Api/src/core/testExtensions/ParameterContext.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+namespace GdUnit4.Core.TestExtensions;
+
+using System.Reflection;
+
+using Api;
+
+internal class ParameterContext(ParameterInfo parameterInfo) : IParameterContext
+{
+    public ParameterInfo GetParameterInfo() => parameterInfo;
+}


### PR DESCRIPTION
# Why

In order to be usable, the `IParameterContext` interface will need to have a concrete implementation.

# What

`ParamterContext` is an internal class that takes a `ParameterInfo` as a constructor argument and returns it from `GetParameterInfo()`