### PR TITLE
GD-400: Create IExtensionRegistry interface

### DIFF
--- a/Api/src/core/testExtensions/IExtensionRegistry.cs
+++ b/Api/src/core/testExtensions/IExtensionRegistry.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+namespace GdUnit4.Core.TestExtensions;
+
+using System.Reflection;
+
+using Api;
+
+/// <summary>
+/// Interface for class which discovers and manages test extensions registered via <see cref="ExtendWithAttribute{T}"/> and
+/// <see cref="RegisterExtensionAttribute"/>, and orchestrates their lifecycle callbacks and parameter resolution.
+/// </summary>
+internal interface IExtensionRegistry
+{
+    /// <summary>
+    /// Runs <see cref="IBeforeAllCallback.BeforeAll"/> for all suite-level extensions in registration order.
+    /// </summary>
+    /// <param name="context">The extension context.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task RunBeforeAll(IExtensionContext context);
+
+    /// <summary>
+    /// Runs <see cref="IAfterAllCallback.AfterAll"/> for all suite-level extensions in reverse registration order.
+    /// </summary>
+    /// <param name="context">The extension context.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task RunAfterAll(IExtensionContext context);
+
+    /// <summary>
+    /// Runs <see cref="IBeforeEachCallback.BeforeEach"/> for suite-level and method-level extensions in registration order.
+    /// </summary>
+    /// <param name="context">The extension context.</param>
+    /// <param name="testMethod">The test method for which to run method-level extensions.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task RunBeforeEach(IExtensionContext context, MethodInfo testMethod);
+
+    /// <summary>
+    /// Runs <see cref="IAfterEachCallback.AfterEach"/> for suite-level and method-level extensions in reverse registration order.
+    /// </summary>
+    /// <param name="context">The extension context.</param>
+    /// <param name="testMethod">The test method for which to run method-level extensions.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task RunAfterEach(IExtensionContext context, MethodInfo testMethod);
+
+    /// <summary>
+    /// Resolves method arguments by applying <see cref="IParameterResolver"/> extensions first,
+    /// then type-matching remaining <paramref name="testCaseArguments"/> to unresolved parameters.
+    /// </summary>
+    /// <param name="method">The test method whose parameters need to be resolved.</param>
+    /// <param name="context">The extension context, which has already had <see cref="IExtensionRegistry.RunBeforeEach"/> called.</param>
+    /// <param name="testCaseArguments">The raw arguments from <c>[TestCase(...)]</c>.</param>
+    /// <returns>An array of resolved argument values matching the method's parameter list.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a parameter cannot be resolved by any extension or by type-matching the remaining
+    /// <paramref name="testCaseArguments"/>.
+    /// </exception>
+    object?[] ResolveArguments(MethodInfo method, IExtensionContext context, object?[] testCaseArguments);
+}


### PR DESCRIPTION
# Why

Despite being an internal class, I wanted to clearly define the API for the extension registry before I started implementing it,  so I created this interface first so we'd have an opportunity to discuss.

I wanted to make it so that when the actual test execution flow is updated to include extension that the change would be as minimal as possible. So instead of being a simple collection of extensions, it has methods for running all test extension lifecycle callbacks for a given suite or test.

# What

Proposed interface (wherein the registry is responsible for both collecting and executing test extensions):

```csharp
/// <summary>
/// Interface for class which discovers and manages test extensions registered via <see cref="ExtendWithAttribute{T}"/> and
/// <see cref="RegisterExtensionAttribute"/>, and orchestrates their lifecycle callbacks and parameter resolution.
/// </summary>
internal interface IExtensionRegistry
{
    /// <summary>
    /// Runs <see cref="IBeforeAllCallback.BeforeAll"/> for all suite-level extensions in registration order.
    /// </summary>
    /// <param name="context">The extension context.</param>
    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
    Task RunBeforeAll(IExtensionContext context);

    /// <summary>
    /// Runs <see cref="IAfterAllCallback.AfterAll"/> for all suite-level extensions in reverse registration order.
    /// </summary>
    /// <param name="context">The extension context.</param>
    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
    Task RunAfterAll(IExtensionContext context);

    /// <summary>
    /// Runs <see cref="IBeforeEachCallback.BeforeEach"/> for suite-level and method-level extensions in registration order.
    /// </summary>
    /// <param name="context">The extension context.</param>
    /// <param name="testMethod">The test method for which to run method-level extensions.</param>
    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
    Task RunBeforeEach(IExtensionContext context, MethodInfo testMethod);

    /// <summary>
    /// Runs <see cref="IAfterEachCallback.AfterEach"/> for suite-level and method-level extensions in reverse registration order.
    /// </summary>
    /// <param name="context">The extension context.</param>
    /// <param name="testMethod">The test method for which to run method-level extensions.</param>
    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
    Task RunAfterEach(IExtensionContext context, MethodInfo testMethod);

    /// <summary>
    /// Resolves method arguments by applying <see cref="IParameterResolver"/> extensions first,
    /// then type-matching remaining <paramref name="testCaseArguments"/> to unresolved parameters.
    /// </summary>
    /// <param name="method">The test method whose parameters need to be resolved.</param>
    /// <param name="context">The extension context, which has already had <see cref="IExtensionRegistry.RunBeforeEach"/> called.</param>
    /// <param name="testCaseArguments">The raw arguments from <c>[TestCase(...)]</c>.</param>
    /// <returns>An array of resolved argument values matching the method's parameter list.</returns>
    /// <exception cref="InvalidOperationException">
    /// Thrown when a parameter cannot be resolved by any extension or by type-matching the remaining
    /// <paramref name="testCaseArguments"/>.
    /// </exception>
    object?[] ResolveArguments(MethodInfo method, IExtensionContext context, object?[] testCaseArguments);
}
```