### PR TITLE
GD-400: Begin implementing `ExtensionRegistry`

### DIFF
--- a/Api.Test/src/core/testExtensions/ExtensionRegistryTest.cs
+++ b/Api.Test/src/core/testExtensions/ExtensionRegistryTest.cs
@@ -1,0 +1,141 @@
+using System.Threading.Tasks;
+using GdUnit4.Api;
+using GdUnit4.Core.TestExtensions;
+using static GdUnit4.Assertions;
+
+namespace GdUnit4.Tests.Core.TestExtensions;
+
+[TestSuite]
+public class ExtensionRegistryTest
+{
+    #region Mock extension classes for testing
+
+    private abstract class MockExtension : IBeforeEachCallback
+    {
+        public Task BeforeEach(IExtensionContext context)
+        {
+            // No-op
+            return Task.CompletedTask;
+        }
+    }
+
+    private class ExtensionA : MockExtension;
+
+    private class ExtensionB : MockExtension;
+    
+    private class ExtensionC : MockExtension;
+
+    private class ExtensionD : MockExtension;
+
+    #endregion
+    
+    #region Mock suite classes for testing
+    
+    [ExtendWith<ExtensionA>]
+    private class SuiteWithExtendWith;
+
+    private class SuiteWithRegisterExtensionField
+    {
+        [RegisterExtension]
+        private static readonly ITestExtension Extension = new ExtensionB();
+    }
+
+    [ExtendWith<ExtensionA>]
+    private class SuiteWithBothRegistrationMethods
+    {
+        [RegisterExtension]
+        private static readonly ITestExtension Extension = new ExtensionB();
+    }
+
+    [ExtendWith<ExtensionA>]
+    [ExtendWith<ExtensionB>]
+    private class AbstractSuite;
+
+    [ExtendWith<ExtensionC>]
+    [ExtendWith<ExtensionD>]
+    private class ConcreteSuite : AbstractSuite;
+
+    private class SuiteWithNoExtensions;
+    
+    #endregion
+
+    #region Test setup
+
+    private ExtensionRegistry extensionRegistry = null!;
+
+    [BeforeTest]
+    public void CreateExtensionRegistry()
+    {
+        extensionRegistry = new ExtensionRegistry();
+    }
+
+    #endregion
+    
+    #region Test FindTestExtensions
+
+    [TestCase]
+    public void FindTestExtensions_WhenCalledOnSuiteWithNoExtensions_ReturnsEmpty()
+    {
+        var result = extensionRegistry
+            .FindTestExtensions(typeof(SuiteWithNoExtensions));
+        
+        AssertThat(result).IsEmpty();
+    }
+
+
+    [TestCase]
+    public void FindTestExtensions_WhenCalledOnSuiteWithExtendWith_ReturnsExtension()
+    {
+        var result = extensionRegistry
+            .FindTestExtensions(typeof(SuiteWithExtendWith));
+        
+        AssertThat(result).IsNotEmpty();
+        AssertThat(result[0].GetType())
+            .IsEqual(typeof(ExtensionA));
+    }
+    
+    [TestCase]
+    public void FindTestExtensions_WhenCalledOnSuiteWithBothExtensions_ReturnsExtensionsInCorrectOrder()
+    {
+        var result = extensionRegistry
+            .FindTestExtensions(typeof(SuiteWithBothRegistrationMethods));
+        
+        AssertThat(result).IsNotEmpty();
+        AssertThat(result[0].GetType())
+            .IsEqual(typeof(ExtensionA));
+        AssertThat(result[1].GetType())
+            .IsEqual(typeof(ExtensionB));
+    }
+
+    [TestCase]
+    public void FindTestExtensions_CollectsInheritedExtensionsInCorrectOrder()
+    {
+        var result = extensionRegistry
+            .FindTestExtensions(typeof(ConcreteSuite));
+        
+        AssertThat(result).IsNotEmpty();
+        AssertInt(result.Count).IsEqual(4);
+        AssertThat(result[0].GetType())
+            .IsEqual(typeof(ExtensionA));
+        AssertThat(result[1].GetType())
+            .IsEqual(typeof(ExtensionB));
+        AssertThat(result[2].GetType())
+            .IsEqual(typeof(ExtensionC));
+        AssertThat(result[3].GetType())
+            .IsEqual(typeof(ExtensionD));
+    }
+
+    [TestCase]
+    public void FindTestExtensions_WhenCalledOnSuiteWithRegisterExtension_ReturnsExtension()
+    {
+        var result = extensionRegistry
+            .FindTestExtensions(typeof(SuiteWithRegisterExtensionField));
+        
+        AssertThat(result).IsNotEmpty();
+        
+        AssertThat(result[0].GetType())
+            .IsEqual(typeof(ExtensionB));
+    }
+
+    #endregion
+}

--- a/Api.Test/src/core/testExtensions/ExtensionRegistryTest.cs
+++ b/Api.Test/src/core/testExtensions/ExtensionRegistryTest.cs
@@ -1,9 +1,12 @@
-using System.Threading.Tasks;
-using GdUnit4.Api;
-using GdUnit4.Core.TestExtensions;
 using static GdUnit4.Assertions;
 
 namespace GdUnit4.Tests.Core.TestExtensions;
+
+using System.Threading.Tasks;
+
+using Api;
+
+using GdUnit4.Core.TestExtensions;
 
 [TestSuite]
 public class ExtensionRegistryTest
@@ -12,39 +15,37 @@ public class ExtensionRegistryTest
 
     private abstract class MockExtension : IBeforeEachCallback
     {
-        public Task BeforeEach(IExtensionContext context)
-        {
+        public Task BeforeEach(IExtensionContext context) =>
             // No-op
-            return Task.CompletedTask;
-        }
+            Task.CompletedTask;
     }
 
     private class ExtensionA : MockExtension;
 
     private class ExtensionB : MockExtension;
-    
+
     private class ExtensionC : MockExtension;
 
     private class ExtensionD : MockExtension;
 
     #endregion
-    
-    #region Mock suite classes for testing
-    
-    [ExtendWith<ExtensionA>]
-    private class SuiteWithExtendWith;
 
-    private class SuiteWithRegisterExtensionField
+    #region Mock suite classes for testing
+
+    [ExtendWith<ExtensionA>]
+    private class SuiteWithExtension;
+
+    private class SuiteWithRegisterExtension
     {
-        [RegisterExtension]
-        private static readonly ITestExtension Extension = new ExtensionB();
+        // ReSharper disable once UnusedMember.Local
+        [RegisterExtension] private static readonly ITestExtension Extension = new ExtensionB();
     }
 
     [ExtendWith<ExtensionA>]
-    private class SuiteWithBothRegistrationMethods
+    private class SuiteWithExtensionsAndRegistration
     {
-        [RegisterExtension]
-        private static readonly ITestExtension Extension = new ExtensionB();
+        // ReSharper disable once UnusedMember.Local
+        [RegisterExtension] private static readonly ITestExtension Extension = new ExtensionB();
     }
 
     [ExtendWith<ExtensionA>]
@@ -53,88 +54,76 @@ public class ExtensionRegistryTest
 
     [ExtendWith<ExtensionC>]
     [ExtendWith<ExtensionD>]
-    private class ConcreteSuite : AbstractSuite;
+    private class SuiteWithExtensionsInherits : AbstractSuite;
 
     private class SuiteWithNoExtensions;
-    
+
     #endregion
 
     #region Test setup
 
+    // ReSharper disable once NullableWarningSuppressionIsUsed
     private ExtensionRegistry extensionRegistry = null!;
 
     [BeforeTest]
-    public void CreateExtensionRegistry()
-    {
-        extensionRegistry = new ExtensionRegistry();
-    }
+    public void CreateExtensionRegistry() => extensionRegistry = new ExtensionRegistry();
 
     #endregion
-    
+
     #region Test FindTestExtensions
 
     [TestCase]
-    public void FindTestExtensions_WhenCalledOnSuiteWithNoExtensions_ReturnsEmpty()
+    public void FindTestExtensions_OnSuiteWithNoExtensions()
     {
         var result = extensionRegistry
             .FindTestExtensions(typeof(SuiteWithNoExtensions));
-        
+
         AssertThat(result).IsEmpty();
     }
 
 
     [TestCase]
-    public void FindTestExtensions_WhenCalledOnSuiteWithExtendWith_ReturnsExtension()
+    public void FindTestExtensions_OnSuiteWithExtension()
     {
         var result = extensionRegistry
-            .FindTestExtensions(typeof(SuiteWithExtendWith));
-        
-        AssertThat(result).IsNotEmpty();
-        AssertThat(result[0].GetType())
-            .IsEqual(typeof(ExtensionA));
-    }
-    
-    [TestCase]
-    public void FindTestExtensions_WhenCalledOnSuiteWithBothExtensions_ReturnsExtensionsInCorrectOrder()
-    {
-        var result = extensionRegistry
-            .FindTestExtensions(typeof(SuiteWithBothRegistrationMethods));
-        
-        AssertThat(result).IsNotEmpty();
-        AssertThat(result[0].GetType())
-            .IsEqual(typeof(ExtensionA));
-        AssertThat(result[1].GetType())
-            .IsEqual(typeof(ExtensionB));
+            .FindTestExtensions(typeof(SuiteWithExtension));
+
+        AssertThat(result)
+            .Extract("GetType")
+            .ContainsExactly(typeof(ExtensionA));
     }
 
     [TestCase]
-    public void FindTestExtensions_CollectsInheritedExtensionsInCorrectOrder()
+    public void FindTestExtensions_OnSuiteWithExtensionsAndRegistration()
     {
         var result = extensionRegistry
-            .FindTestExtensions(typeof(ConcreteSuite));
-        
-        AssertThat(result).IsNotEmpty();
-        AssertInt(result.Count).IsEqual(4);
-        AssertThat(result[0].GetType())
-            .IsEqual(typeof(ExtensionA));
-        AssertThat(result[1].GetType())
-            .IsEqual(typeof(ExtensionB));
-        AssertThat(result[2].GetType())
-            .IsEqual(typeof(ExtensionC));
-        AssertThat(result[3].GetType())
-            .IsEqual(typeof(ExtensionD));
+            .FindTestExtensions(typeof(SuiteWithExtensionsAndRegistration));
+
+        AssertThat(result)
+            .Extract("GetType")
+            .ContainsExactly(typeof(ExtensionA), typeof(ExtensionB));
     }
 
     [TestCase]
-    public void FindTestExtensions_WhenCalledOnSuiteWithRegisterExtension_ReturnsExtension()
+    public void FindTestExtensions_OnSuiteWithExtensionsInherits()
     {
         var result = extensionRegistry
-            .FindTestExtensions(typeof(SuiteWithRegisterExtensionField));
-        
-        AssertThat(result).IsNotEmpty();
-        
-        AssertThat(result[0].GetType())
-            .IsEqual(typeof(ExtensionB));
+            .FindTestExtensions(typeof(SuiteWithExtensionsInherits));
+
+        AssertThat(result)
+            .Extract("GetType")
+            .ContainsExactly(typeof(ExtensionA), typeof(ExtensionB), typeof(ExtensionC), typeof(ExtensionD));
+    }
+
+    [TestCase]
+    public void FindTestExtensions_OnSuiteWithRegisterExtension()
+    {
+        var result = extensionRegistry
+            .FindTestExtensions(typeof(SuiteWithRegisterExtension));
+
+        AssertThat(result)
+            .Extract("GetType")
+            .ContainsExactly(typeof(ExtensionB));
     }
 
     #endregion

--- a/Api/src/core/attributes/ExtendWithAttribute.cs
+++ b/Api/src/core/attributes/ExtendWithAttribute.cs
@@ -8,29 +8,24 @@ namespace GdUnit4;
 using Api;
 
 /// <summary>
-/// Extends the test suite or test method with the specified test extension, hooking it into the test lifecycle
-/// and enabling its callbacks and parameter injection for the annotated class or method.
-///
+/// Extends the test suite with the specified test extension, hooking it into the test lifecycle
+/// and enabling its callbacks and parameter injection for the annotated class.
 /// Note that extensions registered using this attribute <i>must</i> have a no-argument constructor or the test
 /// framework will be unable to instantiate them.
-///
 /// Usage:
-///
 /// <code>
-/// [TestSuite]
-/// [ExtendWith&lt;SomeExtension&gt;]
-/// public class SomeTestSuite
-/// {
-///   [TestCase]
-///   public void SomeTestCase()
+///   [TestSuite]
+///   [ExtendWith&lt;SomeExtension&gt;]
+///   public class SomeTestSuite
 ///   {
 ///   }
-/// }
 /// </code>
-///
-/// As demonstrated, this attribute can be applied to either test cases or suites.
 /// </summary>
 /// <typeparam name="T">The type of the extension to register.</typeparam>
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
-public sealed class ExtendWithAttribute<T> : Attribute
-    where T : ITestExtension, new();
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public sealed class ExtendWithAttribute<T> : ExtendWithBaseAttribute
+    where T : ITestExtension, new()
+{
+    /// <inheritdoc />
+    public override ITestExtension CreateExtension() => new T();
+}

--- a/Api/src/core/attributes/ExtendWithBaseAttribute.cs
+++ b/Api/src/core/attributes/ExtendWithBaseAttribute.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+// ReSharper disable once CheckNamespace
+// Need to be placed in the root namespace to be accessible by the test runner.
+namespace GdUnit4;
+
+using Api;
+
+/// <summary>
+/// Non-generic base for <see cref="ExtendWithAttribute{T}"/>, used to discover and instantiate
+/// test extensions without knowing the concrete type parameter at the call site.
+/// </summary>
+public abstract class ExtendWithBaseAttribute : Attribute
+{
+    /// <summary>Creates and returns a new instance of the registered <see cref="ITestExtension"/>.</summary>
+    /// <returns>A new <see cref="ITestExtension"/> instance.</returns>
+    public abstract ITestExtension CreateExtension();
+}

--- a/Api/src/core/attributes/RegisterExtensionAttribute.cs
+++ b/Api/src/core/attributes/RegisterExtensionAttribute.cs
@@ -26,5 +26,5 @@ namespace GdUnit4;
 /// }
 /// </code>
 /// </summary>
-[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+[AttributeUsage(AttributeTargets.Field)]
 public sealed class RegisterExtensionAttribute : Attribute;

--- a/Api/src/core/attributes/RegisterExtensionAttribute.cs
+++ b/Api/src/core/attributes/RegisterExtensionAttribute.cs
@@ -8,6 +8,8 @@ namespace GdUnit4;
 /// <summary>
 /// Registers the annotated field or property as a test extension, allowing it to be used for lifecycle callbacks and
 /// parameter injection in the test suite. Using this method allows for the registration of extensions with constructor
+/// Registers the annotated field as a test extension, allowing it to be used for lifecycle callbacks and
+/// parameter injection in the test suite. Using this method allows for the registration of extensions with constructor
 /// arguments.
 ///
 /// Usage:

--- a/Api/src/core/testExtensions/ExtensionRegistry.cs
+++ b/Api/src/core/testExtensions/ExtensionRegistry.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 using Api;
 
-internal class ExtensionRegistry
+internal sealed class ExtensionRegistry
 {
     private readonly List<ITestExtension> extensions = [];
 
@@ -31,26 +31,18 @@ internal class ExtensionRegistry
     // Collected order: XXX → YYY → Foo → Bar
     internal static List<ITestExtension> CollectExtendWithExtensions(Type type) =>
     [
-        .. Enumerable
-            .SelectMany<Type, ExtendWithBaseAttribute>(GetTypeHierarchy(type), t => t.GetCustomAttributes<ExtendWithBaseAttribute>(inherit: false))
+        .. GetTypeHierarchy(type)
+            .SelectMany<Type, ExtendWithBaseAttribute>(t => t.GetCustomAttributes<ExtendWithBaseAttribute>(false))
             .Select(attr => attr.CreateExtension())
     ];
 
-    internal static List<ITestExtension> CollectRegisterExtensions(Type type)
-    {
-        List<ITestExtension> extensions = [];
-
-        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
-        {
-            if (!field.IsDefined(typeof(RegisterExtensionAttribute)))
-                continue;
-
-            if (field.GetValue(null) is ITestExtension ext)
-                extensions.Add(ext);
-        }
-
-        return extensions;
-    }
+    internal static List<ITestExtension> CollectRegisterExtensions(Type type) =>
+    [
+        .. type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(field => field.IsDefined(typeof(RegisterExtensionAttribute)))
+            .Select(field => field.GetValue(null))
+            .OfType<ITestExtension>()
+    ];
 
     // Walks the inheritance chain from the root base type down to the given type
     private static Stack<Type> GetTypeHierarchy(Type type)

--- a/Api/src/core/testExtensions/ExtensionRegistry.cs
+++ b/Api/src/core/testExtensions/ExtensionRegistry.cs
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+namespace GdUnit4.Core.TestExtensions;
+
+using System.Collections.ObjectModel;
+using System.Reflection;
+
+using Api;
+
+internal class ExtensionRegistry
+{
+    private readonly List<ITestExtension> extensions = [];
+
+    public ReadOnlyCollection<ITestExtension> FindTestExtensions(Type type)
+    {
+        extensions.Clear();
+        extensions.AddRange(CollectExtendWithExtensions(type));
+        extensions.AddRange(CollectRegisterExtensions(type));
+        return extensions.AsReadOnly();
+    }
+
+    // Example:
+    //   [ExtendWith<XXX>]
+    //   [ExtendWith<YYY>]
+    //   class BaseSuite { }
+    //
+    //   [ExtendWith<Foo>]
+    //   [ExtendWith<Bar>]
+    //   class TestSuiteA : BaseSuite { }
+    //
+    // Collected order: XXX → YYY → Foo → Bar
+    internal static List<ITestExtension> CollectExtendWithExtensions(Type type) =>
+    [
+        .. Enumerable
+            .SelectMany<Type, ExtendWithBaseAttribute>(GetTypeHierarchy(type), t => t.GetCustomAttributes<ExtendWithBaseAttribute>(inherit: false))
+            .Select(attr => attr.CreateExtension())
+    ];
+
+    internal static List<ITestExtension> CollectRegisterExtensions(Type type)
+    {
+        List<ITestExtension> extensions = [];
+
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
+        {
+            if (!field.IsDefined(typeof(RegisterExtensionAttribute)))
+                continue;
+
+            if (field.GetValue(null) is ITestExtension ext)
+                extensions.Add(ext);
+        }
+
+        return extensions;
+    }
+
+    // Walks the inheritance chain from the root base type down to the given type
+    private static Stack<Type> GetTypeHierarchy(Type type)
+    {
+        var hierarchy = new Stack<Type>();
+        var current = type;
+        while (current != null && current != typeof(object))
+        {
+            hierarchy.Push(current);
+            current = current.BaseType;
+        }
+
+        return hierarchy;
+    }
+}


### PR DESCRIPTION
# Why

In order to make this rather large class easier to manage during the review process, I've split it into multiple smaller chunks.

This first PR focuses on the `FindTestExtensions` method, and includes a comprehensive test suite.

# What

This is the (incomplete) `ExtensionRegistry` class. This portion implements the test extension collection method `FindTestExtensions`.

Also includes other changes to attributes from previous PR feedback, ensuring that:
- The `ExtendWithBaseAttribute` class exists
- The `ExtendWith<T>` attribute implements `ExtendWithBaseAttribute`
- `ExtendWith` cannot be applied to methods
- `RegisterExtension` cannot be applied to properties