### PR TITLE
GD-400: Add Run* methods to ExtensionRegistry

### DIFF
--- a/Api.Test/src/core/testExtensions/ExtensionRegistryTest.cs
+++ b/Api.Test/src/core/testExtensions/ExtensionRegistryTest.cs
@@ -15,30 +15,30 @@ public class ExtensionRegistryTest
 {
     #region Mock extension classes for testing
 
-    private abstract class MockExtension(List<Type> invocationLog) 
+    private abstract class MockExtension(List<string> invocationLog) 
         : IBeforeAllCallback, IBeforeEachCallback, IAfterEachCallback, IAfterAllCallback
     {
         public Task BeforeEach(IExtensionContext context)
         {
-            invocationLog.Add(GetType());
+            invocationLog.Add(GetType().Name + ".BeforeEach");
             return Task.CompletedTask;
         }
 
         public Task BeforeAll(IExtensionContext context)
         {
-            invocationLog.Add(GetType());
+            invocationLog.Add(GetType().Name + ".BeforeAll");
             return Task.CompletedTask;
         }
 
         public Task AfterEach(IExtensionContext context)
         {
-            invocationLog.Add(GetType());
+            invocationLog.Add(GetType().Name + ".AfterEach");
             return Task.CompletedTask;
         }
 
         public Task AfterAll(IExtensionContext context)
         {
-            invocationLog.Add(GetType());
+            invocationLog.Add(GetType().Name + ".AfterAll");
             return Task.CompletedTask;
         }
     }
@@ -77,7 +77,11 @@ public class ExtensionRegistryTest
 
     [ExtendWith<ExtensionC>]
     [ExtendWith<ExtensionD>]
-    private class SuiteWithExtensionsInherits : AbstractSuite;
+    private class SuiteWithExtensionsInherits : AbstractSuite
+    {
+        [TestCase]
+        public void TestMethod() {}
+    }
 
     private class SuiteWithNoExtensions;
 
@@ -85,7 +89,7 @@ public class ExtensionRegistryTest
 
     #region Test setup
 
-    private static readonly List<Type> InvokedExtensions = [];
+    private static readonly List<string> InvokedExtensions = [];
 
     // ReSharper disable once NullableWarningSuppressionIsUsed
     private ExtensionRegistry extensionRegistry = null!;
@@ -179,16 +183,23 @@ public class ExtensionRegistryTest
         await extensionRegistry.RunBeforeAll(context);
         
         AssertThat(InvokedExtensions)
-            .ContainsExactly(typeof(ExtensionA), typeof(ExtensionB), typeof(ExtensionC), typeof(ExtensionD));
+            .ContainsExactly(
+                nameof(ExtensionA) + ".BeforeAll",
+                nameof(ExtensionB) + ".BeforeAll",
+                nameof(ExtensionC) + ".BeforeAll",
+                nameof(ExtensionD) + ".BeforeAll"
+                );
     }
 
     [TestCase]
     public async Task RunBeforeEach_ShouldExecuteExtensionsInCorrectOrder()
     {
-        extensionRegistry.FindTestExtensions(typeof(SuiteWithExtensionsInherits));
+        var testSuiteType = typeof(SuiteWithExtensionsInherits);
+        var testMethod = testSuiteType.GetMethod(nameof(SuiteWithExtensionsInherits.TestMethod))!;
+        extensionRegistry.FindTestExtensions(testSuiteType);
         
-        var context = new ExtensionContext(
-            typeof(SuiteWithExtensionsInherits),
+        var suiteContext = new ExtensionContext(
+            testSuiteType,
             new TestSuiteNode
             {
                 ManagedType = "null",
@@ -198,20 +209,34 @@ public class ExtensionRegistryTest
                 Id = Guid.NewGuid(),
                 ParentId = Guid.NewGuid()
             });
+
+        var testContext = new ExtensionContext(
+            suiteContext,
+            testMethod,
+            testMethod.Name,
+            []
+        );
         
-        await extensionRegistry.RunBeforeEach(context);
+        await extensionRegistry.RunBeforeEach(testContext);
         
         AssertThat(InvokedExtensions)
-            .ContainsExactly(typeof(ExtensionA), typeof(ExtensionB), typeof(ExtensionC), typeof(ExtensionD));
+            .ContainsExactly(
+                nameof(ExtensionA) + ".BeforeEach",
+                nameof(ExtensionB) + ".BeforeEach",
+                nameof(ExtensionC) + ".BeforeEach",
+                nameof(ExtensionD) + ".BeforeEach"
+                );
     }
 
     [TestCase]
     public async Task RunAfterEach_ShouldExecuteExtensionsInReverseOrder()
     {
-        extensionRegistry.FindTestExtensions(typeof(SuiteWithExtensionsInherits));
+        var testSuiteType = typeof(SuiteWithExtensionsInherits);
+        var testMethod = testSuiteType.GetMethod(nameof(SuiteWithExtensionsInherits.TestMethod))!;
+        extensionRegistry.FindTestExtensions(testSuiteType);
         
-        var context = new ExtensionContext(
-            typeof(SuiteWithExtensionsInherits),
+        var suiteContext = new ExtensionContext(
+            testSuiteType,
             new TestSuiteNode
             {
                 ManagedType = "null",
@@ -221,11 +246,23 @@ public class ExtensionRegistryTest
                 Id = Guid.NewGuid(),
                 ParentId = Guid.NewGuid()
             });
+
+        var testContext = new ExtensionContext(
+            suiteContext,
+            testMethod,
+            testMethod.Name,
+            []
+        );
         
-        await extensionRegistry.RunAfterEach(context);
+        await extensionRegistry.RunAfterEach(testContext);
         
         AssertThat(InvokedExtensions)
-            .ContainsExactly(typeof(ExtensionD), typeof(ExtensionC), typeof(ExtensionB), typeof(ExtensionA));
+            .ContainsExactly(
+                nameof(ExtensionD) + ".AfterEach",
+                nameof(ExtensionC) + ".AfterEach",
+                nameof(ExtensionB) + ".AfterEach",
+                nameof(ExtensionA) + ".AfterEach"
+                );
     }
 
     [TestCase]
@@ -233,7 +270,7 @@ public class ExtensionRegistryTest
     {
         extensionRegistry.FindTestExtensions(typeof(SuiteWithExtensionsInherits));
         
-        var context = new ExtensionContext(
+        var suiteContext = new ExtensionContext(
             typeof(SuiteWithExtensionsInherits),
             new TestSuiteNode
             {
@@ -245,10 +282,15 @@ public class ExtensionRegistryTest
                 ParentId = Guid.NewGuid()
             });
         
-        await extensionRegistry.RunAfterAll(context);
+        await extensionRegistry.RunAfterAll(suiteContext);
         
         AssertThat(InvokedExtensions)
-            .ContainsExactly(typeof(ExtensionD), typeof(ExtensionC), typeof(ExtensionB), typeof(ExtensionA));
+            .ContainsExactly(
+                nameof(ExtensionD) + ".AfterAll",
+                nameof(ExtensionC) + ".AfterAll",
+                nameof(ExtensionB) + ".AfterAll",
+                nameof(ExtensionA) + ".AfterAll"
+                );
     }
     
     #endregion

--- a/Api.Test/src/core/testExtensions/ExtensionRegistryTest.cs
+++ b/Api.Test/src/core/testExtensions/ExtensionRegistryTest.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using static GdUnit4.Assertions;
 
 namespace GdUnit4.Tests.Core.TestExtensions;
@@ -13,20 +15,41 @@ public class ExtensionRegistryTest
 {
     #region Mock extension classes for testing
 
-    private abstract class MockExtension : IBeforeEachCallback
+    private abstract class MockExtension(List<Type> invocationLog) 
+        : IBeforeAllCallback, IBeforeEachCallback, IAfterEachCallback, IAfterAllCallback
     {
-        public Task BeforeEach(IExtensionContext context) =>
-            // No-op
-            Task.CompletedTask;
+        public Task BeforeEach(IExtensionContext context)
+        {
+            invocationLog.Add(GetType());
+            return Task.CompletedTask;
+        }
+
+        public Task BeforeAll(IExtensionContext context)
+        {
+            invocationLog.Add(GetType());
+            return Task.CompletedTask;
+        }
+
+        public Task AfterEach(IExtensionContext context)
+        {
+            invocationLog.Add(GetType());
+            return Task.CompletedTask;
+        }
+
+        public Task AfterAll(IExtensionContext context)
+        {
+            invocationLog.Add(GetType());
+            return Task.CompletedTask;
+        }
     }
 
-    private class ExtensionA : MockExtension;
+    private class ExtensionA() : MockExtension(InvokedExtensions);
 
-    private class ExtensionB : MockExtension;
+    private class ExtensionB() : MockExtension(InvokedExtensions);
 
-    private class ExtensionC : MockExtension;
+    private class ExtensionC() : MockExtension(InvokedExtensions);
 
-    private class ExtensionD : MockExtension;
+    private class ExtensionD() : MockExtension(InvokedExtensions);
 
     #endregion
 
@@ -62,11 +85,17 @@ public class ExtensionRegistryTest
 
     #region Test setup
 
+    private static readonly List<Type> InvokedExtensions = [];
+
     // ReSharper disable once NullableWarningSuppressionIsUsed
     private ExtensionRegistry extensionRegistry = null!;
 
     [BeforeTest]
-    public void CreateExtensionRegistry() => extensionRegistry = new ExtensionRegistry();
+    public void SetUpExtensions()
+    {
+        extensionRegistry = new ExtensionRegistry();
+        InvokedExtensions.Clear();
+    }
 
     #endregion
 
@@ -126,5 +155,101 @@ public class ExtensionRegistryTest
             .ContainsExactly(typeof(ExtensionB));
     }
 
+    #endregion
+    
+    #region Test run methods
+
+    [TestCase]
+    public async Task RunBeforeAll_ShouldExecuteExtensionsInCorrectOrder()
+    {
+        extensionRegistry.FindTestExtensions(typeof(SuiteWithExtensionsInherits));
+        
+        var context = new ExtensionContext(
+            typeof(SuiteWithExtensionsInherits),
+            new TestSuiteNode
+            {
+                ManagedType = "null",
+                Tests = [],
+                AssemblyPath = "null",
+                SourceFile = "null",
+                Id = Guid.NewGuid(),
+                ParentId = Guid.NewGuid()
+            });
+        
+        await extensionRegistry.RunBeforeAll(context);
+        
+        AssertThat(InvokedExtensions)
+            .ContainsExactly(typeof(ExtensionA), typeof(ExtensionB), typeof(ExtensionC), typeof(ExtensionD));
+    }
+
+    [TestCase]
+    public async Task RunBeforeEach_ShouldExecuteExtensionsInCorrectOrder()
+    {
+        extensionRegistry.FindTestExtensions(typeof(SuiteWithExtensionsInherits));
+        
+        var context = new ExtensionContext(
+            typeof(SuiteWithExtensionsInherits),
+            new TestSuiteNode
+            {
+                ManagedType = "null",
+                Tests = [],
+                AssemblyPath = "null",
+                SourceFile = "null",
+                Id = Guid.NewGuid(),
+                ParentId = Guid.NewGuid()
+            });
+        
+        await extensionRegistry.RunBeforeEach(context);
+        
+        AssertThat(InvokedExtensions)
+            .ContainsExactly(typeof(ExtensionA), typeof(ExtensionB), typeof(ExtensionC), typeof(ExtensionD));
+    }
+
+    [TestCase]
+    public async Task RunAfterEach_ShouldExecuteExtensionsInReverseOrder()
+    {
+        extensionRegistry.FindTestExtensions(typeof(SuiteWithExtensionsInherits));
+        
+        var context = new ExtensionContext(
+            typeof(SuiteWithExtensionsInherits),
+            new TestSuiteNode
+            {
+                ManagedType = "null",
+                Tests = [],
+                AssemblyPath = "null",
+                SourceFile = "null",
+                Id = Guid.NewGuid(),
+                ParentId = Guid.NewGuid()
+            });
+        
+        await extensionRegistry.RunAfterEach(context);
+        
+        AssertThat(InvokedExtensions)
+            .ContainsExactly(typeof(ExtensionD), typeof(ExtensionC), typeof(ExtensionB), typeof(ExtensionA));
+    }
+
+    [TestCase]
+    public async Task RunAfterAll_ShouldExecuteExtensionsInReverseOrder()
+    {
+        extensionRegistry.FindTestExtensions(typeof(SuiteWithExtensionsInherits));
+        
+        var context = new ExtensionContext(
+            typeof(SuiteWithExtensionsInherits),
+            new TestSuiteNode
+            {
+                ManagedType = "null",
+                Tests = [],
+                AssemblyPath = "null",
+                SourceFile = "null",
+                Id = Guid.NewGuid(),
+                ParentId = Guid.NewGuid()
+            });
+        
+        await extensionRegistry.RunAfterAll(context);
+        
+        AssertThat(InvokedExtensions)
+            .ContainsExactly(typeof(ExtensionD), typeof(ExtensionC), typeof(ExtensionB), typeof(ExtensionA));
+    }
+    
     #endregion
 }

--- a/Api/src/core/testExtensions/ExtensionRegistry.cs
+++ b/Api/src/core/testExtensions/ExtensionRegistry.cs
@@ -19,6 +19,30 @@ internal sealed class ExtensionRegistry
         return extensions.AsReadOnly();
     }
 
+    public async Task RunBeforeAll(IExtensionContext extensionContext)
+    {
+        foreach (var extension in extensions.OfType<IBeforeAllCallback>())
+            await extension.BeforeAll(extensionContext).ConfigureAwait(true);
+    }
+
+    public async Task RunBeforeEach(IExtensionContext extensionContext)
+    {
+        foreach (var extension in extensions.OfType<IBeforeEachCallback>())
+            await extension.BeforeEach(extensionContext).ConfigureAwait(true);
+    }
+
+    public async Task RunAfterEach(IExtensionContext extensionContext)
+    {
+        foreach (var extension in extensions.OfType<IAfterEachCallback>().Reverse())
+            await extension.AfterEach(extensionContext).ConfigureAwait(true);
+    }
+
+    public async Task RunAfterAll(IExtensionContext extensionContext)
+    {
+        foreach (var extension in extensions.OfType<IAfterAllCallback>().Reverse())
+            await extension.AfterAll(extensionContext).ConfigureAwait(true);
+    }
+
     // Example:
     //   [ExtendWith<XXX>]
     //   [ExtendWith<YYY>]


### PR DESCRIPTION
# Why

In order to actually execute registered extensions in the correct order.

# What

Four additional methods in `ExtensionRegistry`:
- `RunBeforeAll`
  - Executes all registered `IBeforeAllCallback` extensions, in registration order
- `RunBeforeEach`
  - Executes all registered `IBeforeEachCallback` extensions, in registration order
- `RunAfterEach`
  - Executes all registered `IAfterEachCallback` extensions, in *reverse* registration order
- `RunAfterAll`
  - Executes all registered `IAfterAllCallback` extensions, in *reverse* registration order

This isn't *strictly* part of the initial spec for `ExtensionRegistry` in the feature description:

> ExtensionRegistry — discovers extensions from [ExtendWith<T>]
> attributes and [RegisterExtension] fields, manages ordered lifecycle,
> resolves method parameters with type-based argument matching

But it feels like it falls under the category of "manages ordered lifecycle" which is why I originally put them in this class.

Re: the last portion of the spec, "resolves method parameters with type-based argument matching" based on your comments on the original PR, that actually won't be part of this class, is that correct?