### PR TITLE
GD-426: Add ambient LoggerFactory and LogCapture for testing

### DIFF
--- a/Api.Test/src/core/logging/LogCaptureTest.cs
+++ b/Api.Test/src/core/logging/LogCaptureTest.cs
@@ -1,0 +1,364 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+using static GdUnit4.Assertions;
+
+namespace GdUnit4.Tests.Core.Logging;
+
+using Api;
+
+[TestSuite]
+public class LogCaptureTest
+{
+    #region Log-source stubs
+
+    // Each class owns its logger, mirroring real production code.
+    private class SourceA
+    {
+        internal static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<SourceA>();
+    }
+
+    private class SourceB
+    {
+        internal static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<SourceB>();
+    }
+
+    private class SourceC
+    {
+        internal static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<SourceC>();
+    }
+
+    #endregion
+
+    #region Watch
+
+    [TestCase]
+    public void Watch_SingleType_CapturesMessagesForThatType()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("hello");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "hello", typeof(SourceA)));
+    }
+
+    [TestCase]
+    public void Watch_DoesNotCaptureMessagesForUnregisteredType()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceB.Logger.LogInfo("unrelated");
+
+        AssertThat(capture.Entries).IsEmpty();
+    }
+
+    [TestCase]
+    public void Watch_TwoTypes_CapturesBothSources()
+    {
+        using var capture = LogCapture.Watch<SourceA, SourceB>();
+
+        SourceA.Logger.LogInfo("from-A");
+        SourceB.Logger.LogInfo("from-B");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(
+                new LogEntry(LogLevel.Informational, "from-A", typeof(SourceA)),
+                new LogEntry(LogLevel.Informational, "from-B", typeof(SourceB)));
+    }
+
+    [TestCase]
+    public void Watch_ThreeTypes_CapturesAllThreeSources()
+    {
+        using var capture = LogCapture.Watch<SourceA, SourceB, SourceC>();
+
+        SourceA.Logger.LogInfo("A");
+        SourceB.Logger.LogInfo("B");
+        SourceC.Logger.LogInfo("C");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(
+                new LogEntry(LogLevel.Informational, "A", typeof(SourceA)),
+                new LogEntry(LogLevel.Informational, "B", typeof(SourceB)),
+                new LogEntry(LogLevel.Informational, "C", typeof(SourceC)));
+    }
+
+    [TestCase]
+    public void Watch_ParamsOverload_CapturesAllSpecifiedTypes()
+    {
+        using var capture = LogCapture.Watch(typeof(SourceA), typeof(SourceB), typeof(SourceC));
+
+        SourceA.Logger.LogInfo("A");
+        SourceB.Logger.LogInfo("B");
+        SourceC.Logger.LogInfo("C");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(
+                new LogEntry(LogLevel.Informational, "A", typeof(SourceA)),
+                new LogEntry(LogLevel.Informational, "B", typeof(SourceB)),
+                new LogEntry(LogLevel.Informational, "C", typeof(SourceC)));
+    }
+
+    #endregion
+
+    #region Dispose
+
+    [TestCase]
+    public void Dispose_RemovesCaptureFromRegistry()
+    {
+        var capture = LogCapture.Watch<SourceA>();
+
+        capture.Dispose();
+
+        AssertThat(LogCapture.GetCaptures(typeof(SourceA))).IsEmpty();
+    }
+
+    [TestCase]
+    public void Dispose_RemovesOnlyTheDisposedCapture_WhenTwoCapturesAreActive()
+    {
+        var captureA = LogCapture.Watch<SourceA>();
+        var captureB = LogCapture.Watch<SourceA>();
+
+        captureA.Dispose();
+
+        AssertThat(LogCapture.GetCaptures(typeof(SourceA)))
+            .ContainsExactly(captureB);
+
+        captureB.Dispose();
+    }
+
+    [TestCase]
+    public void Dispose_StopsCapturingMessages()
+    {
+        LogCapture capture;
+        using (capture = LogCapture.Watch<SourceA>())
+        {
+            SourceA.Logger.LogInfo("inside");
+        }
+
+        SourceA.Logger.LogInfo("outside");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "inside", typeof(SourceA)));
+    }
+
+    [TestCase]
+    public void Dispose_IsIdempotent_DoesNotThrow()
+    {
+        var capture = LogCapture.Watch<SourceA>();
+
+        capture.Dispose();
+        capture.Dispose();
+
+        AssertThat(LogCapture.GetCaptures(typeof(SourceA))).IsEmpty();
+    }
+
+    #endregion
+
+    #region Entries
+
+    [TestCase]
+    public void Entries_ReturnsEntriesInEmissionOrder()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("first");
+        SourceA.Logger.LogWarning("second");
+        SourceA.Logger.LogError("third");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(
+                new LogEntry(LogLevel.Informational, "first", typeof(SourceA)),
+                new LogEntry(LogLevel.Warning, "second", typeof(SourceA)),
+                new LogEntry(LogLevel.Error, "third", typeof(SourceA)));
+    }
+
+    [TestCase]
+    public void Entries_IsEmptyWhenNothingLogged()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        AssertThat(capture.Entries).IsEmpty();
+    }
+
+    #endregion
+
+    #region Clear
+
+    [TestCase]
+    public void Clear_RemovesAllCapturedEntries()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("before");
+        capture.Clear();
+
+        AssertThat(capture.Entries).IsEmpty();
+    }
+
+    [TestCase]
+    public void Clear_AllowsCapturingNewEntriesAfterReset()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("before");
+        capture.Clear();
+        SourceA.Logger.LogInfo("after");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "after", typeof(SourceA)));
+    }
+
+    #endregion
+
+    #region Count
+
+    [TestCase]
+    public void Count_ReturnsCorrectCountPerLevel()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("info");
+        SourceA.Logger.LogWarning("warning");
+        SourceA.Logger.LogError("error");
+
+        AssertThat(capture.Count(LogLevel.Informational)).IsEqual(1);
+        AssertThat(capture.Count(LogLevel.Warning)).IsEqual(1);
+        AssertThat(capture.Count(LogLevel.Error)).IsEqual(1);
+    }
+
+    [TestCase]
+    public void Count_ReturnsZeroForLevelWithNoMessages()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("only info");
+
+        AssertThat(capture.Count(LogLevel.Warning)).IsEqual(0);
+        AssertThat(capture.Count(LogLevel.Error)).IsEqual(0);
+    }
+
+    [TestCase]
+    public void Count_AccumulatesAcrossMultipleEmissions()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("a");
+        SourceA.Logger.LogInfo("b");
+        SourceA.Logger.LogInfo("c");
+
+        AssertThat(capture.Count(LogLevel.Informational)).IsEqual(3);
+    }
+
+    #endregion
+
+    #region EntriesOf
+
+    [TestCase]
+    public void EntriesOf_ReturnsOnlyMatchingLevel()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("info");
+        SourceA.Logger.LogWarning("warning");
+        SourceA.Logger.LogError("error");
+
+        AssertThat(capture.EntriesOf(LogLevel.Warning))
+            .ContainsExactly(new LogEntry(LogLevel.Warning, "warning", typeof(SourceA)));
+    }
+
+    [TestCase]
+    public void EntriesOf_ReturnsEmptyListWhenNoneMatch()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("info only");
+
+        AssertThat(capture.EntriesOf(LogLevel.Error)).IsEmpty();
+    }
+
+    [TestCase]
+    public void EntriesOf_RetainsEmissionOrder()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogWarning("w1");
+        SourceA.Logger.LogInfo("skip");
+        SourceA.Logger.LogWarning("w2");
+
+        AssertThat(capture.EntriesOf(LogLevel.Warning))
+            .ContainsExactly(
+                new LogEntry(LogLevel.Warning, "w1", typeof(SourceA)),
+                new LogEntry(LogLevel.Warning, "w2", typeof(SourceA)));
+    }
+
+    #endregion
+
+    #region Parallel captures for the same type
+
+    [TestCase]
+    public void TwoCaptures_ForSameType_BothReceiveMessages()
+    {
+        using var captureA = LogCapture.Watch<SourceA>();
+        using var captureB = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("shared");
+
+        AssertThat(captureA.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "shared", typeof(SourceA)));
+        AssertThat(captureB.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "shared", typeof(SourceA)));
+    }
+
+    [TestCase]
+    public void DisposingOneCapture_DoesNotAffectOther()
+    {
+        var captureA = LogCapture.Watch<SourceA>();
+        using var captureB = LogCapture.Watch<SourceA>();
+
+        captureA.Dispose();
+        SourceA.Logger.LogInfo("after-dispose");
+
+        AssertThat(captureA.Entries).IsEmpty();
+        AssertThat(captureB.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "after-dispose", typeof(SourceA)));
+    }
+
+    #endregion
+
+    #region LogEntry record
+
+    [TestCase]
+    public void LogEntry_EqualWhenAllFieldsMatch()
+    {
+        var a = new LogEntry(LogLevel.Warning, "oops", typeof(SourceA));
+        var b = new LogEntry(LogLevel.Warning, "oops", typeof(SourceA));
+        AssertThat(a).IsEqual(b);
+    }
+
+    [TestCase]
+    public void LogEntry_NotEqualWhenLevelDiffers()
+    {
+        var a = new LogEntry(LogLevel.Warning, "msg", typeof(SourceA));
+        var b = new LogEntry(LogLevel.Error, "msg", typeof(SourceA));
+        AssertThat(a).IsNotEqual(b);
+    }
+
+    [TestCase]
+    public void LogEntry_NotEqualWhenMessageDiffers()
+    {
+        var a = new LogEntry(LogLevel.Informational, "msg-a", typeof(SourceA));
+        var b = new LogEntry(LogLevel.Informational, "msg-b", typeof(SourceA));
+        AssertThat(a).IsNotEqual(b);
+    }
+
+    [TestCase]
+    public void LogEntry_NotEqualWhenSourceDiffers()
+    {
+        var a = new LogEntry(LogLevel.Informational, "msg", typeof(SourceA));
+        var b = new LogEntry(LogLevel.Informational, "msg", typeof(SourceB));
+        AssertThat(a).IsNotEqual(b);
+    }
+
+    #endregion
+}

--- a/Api/src/api/ITestEngineLogger.cs
+++ b/Api/src/api/ITestEngineLogger.cs
@@ -17,21 +17,36 @@ public interface ITestEngineLogger
     /// </summary>
     /// <param name="message">The informational message to log.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void LogInfo(string message) => SendMessage(LogLevel.Informational, message);
+    sealed void LogInfo(string message) => SendMessage(LogLevel.Informational, message);
 
     /// <summary>
     ///     Logs a warning message.
     /// </summary>
     /// <param name="message">The warning message to log.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void LogWarning(string message) => SendMessage(LogLevel.Warning, message);
+    sealed void LogWarning(string message) => SendMessage(LogLevel.Warning, message);
 
     /// <summary>
     ///     Logs an error message.
     /// </summary>
     /// <param name="message">The error message to log.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void LogError(string message) => SendMessage(LogLevel.Error, message);
+    sealed void LogError(string message) => SendMessage(LogLevel.Error, message);
+
+    /// <summary>
+    ///     Logs a debug message. The method body is only compiled in DEBUG builds;
+    ///     in Release builds it is a no-op with no runtime overhead.
+    /// </summary>
+    /// <param name="message">The debug message to log.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    sealed void LogDebug(string message)
+    {
+#if DEBUG
+#pragma warning disable IDE0022 // #if DEBUG cannot be used inside an expression body
+        SendMessage(LogLevel.Debug, message);
+#pragma warning restore IDE0022
+#endif
+    }
 
     /// <summary>
     ///     Sends a message to the enabled loggers.

--- a/Api/src/api/LogCapture.cs
+++ b/Api/src/api/LogCapture.cs
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Api;
+
+using System.Collections.Concurrent;
+
+using Core.Logging;
+
+/// <summary>
+///     A thread-safe test utility that captures log messages emitted by specific classes,
+///     allowing tests to assert on log output without noise from unrelated components.
+/// </summary>
+/// <remarks>
+///     Watch one or more classes, then assert on the collected messages:
+///     <code>
+///     using var capture = LogCapture.Watch&lt;ClassA&gt;();
+///
+///     // exercise code under test
+///
+///     AssertThat(capture.Count(LogLevel.Informational)).IsEqual(1);
+///     </code>
+///     Multiple classes can be watched in a single scope:
+///     <code>
+///     using var capture = LogCapture.Watch&lt;ClassA, ClassB&gt;();
+///     </code>
+///     <see cref="Dispose" /> automatically stops watching so parallel tests do not interfere.
+/// </remarks>
+/// <remarks>
+///     <b>Limitation:</b> only classes that obtain their logger via
+///     <see cref="LoggerFactory.GetLogger{T}" /> are captured. Classes that receive an
+///     <see cref="ITestEngineLogger" /> through constructor injection bypass this mechanism.
+///     Migrate those classes to <c>LoggerFactory.GetLogger&lt;T&gt;()</c> to make them watchable.
+/// </remarks>
+public sealed class LogCapture : IDisposable
+{
+    // Type → set of active captures (thread-safe, O(1) removal via TryRemove)
+    private static readonly ConcurrentDictionary<Type, ConcurrentDictionary<LogCapture, byte>> Registry = new();
+
+    private readonly ConcurrentQueue<LogEntry> captured = new();
+    private readonly Type[] registeredTypes;
+
+    private LogCapture(Type[] types)
+    {
+        registeredTypes = types;
+        foreach (var type in types)
+            _ = Registry.GetOrAdd(type, _ => new ConcurrentDictionary<LogCapture, byte>()).TryAdd(this, 0);
+    }
+
+    /// <summary>Gets all log entries captured so far, in the order they were received.</summary>
+    public IReadOnlyList<LogEntry> Entries => [.. captured];
+
+    /// <summary>
+    ///     Watches log messages emitted by <typeparamref name="T" />.
+    /// </summary>
+    /// <typeparam name="T">The class whose log output should be captured.</typeparam>
+    /// <returns>A <see cref="LogCapture" /> scope that must be disposed at the end of the test.</returns>
+    public static LogCapture Watch<T>() => Watch(typeof(T));
+
+    /// <summary>
+    ///     Watches log messages emitted by <typeparamref name="T1" /> and <typeparamref name="T2" />.
+    /// </summary>
+    /// <typeparam name="T1">The first class whose log output should be captured.</typeparam>
+    /// <typeparam name="T2">The second class whose log output should be captured.</typeparam>
+    /// <returns>A <see cref="LogCapture" /> scope that must be disposed at the end of the test.</returns>
+    public static LogCapture Watch<T1, T2>() => Watch(typeof(T1), typeof(T2));
+
+    /// <summary>
+    ///     Watches log messages emitted by <typeparamref name="T1" />, <typeparamref name="T2" />, and
+    ///     <typeparamref name="T3" />.
+    /// </summary>
+    /// <typeparam name="T1">The first class whose log output should be captured.</typeparam>
+    /// <typeparam name="T2">The second class whose log output should be captured.</typeparam>
+    /// <typeparam name="T3">The third class whose log output should be captured.</typeparam>
+    /// <returns>A <see cref="LogCapture" /> scope that must be disposed at the end of the test.</returns>
+    public static LogCapture Watch<T1, T2, T3>() => Watch(typeof(T1), typeof(T2), typeof(T3));
+
+    /// <summary>
+    ///     Watches log messages emitted by all specified <paramref name="types" />.
+    /// </summary>
+    /// <param name="types">The classes whose log output should be captured.</param>
+    /// <returns>A <see cref="LogCapture" /> scope that must be disposed at the end of the test.</returns>
+    public static LogCapture Watch(params Type[] types) => new(types ?? throw new ArgumentNullException(nameof(types)));
+
+    /// <summary>Stops watching and removes this capture from the registry so no further messages are routed to it.</summary>
+    public void Dispose()
+    {
+        foreach (var type in registeredTypes)
+        {
+            if (Registry.TryGetValue(type, out var captures))
+                _ = captures.TryRemove(this, out _);
+        }
+    }
+
+    /// <summary>Discards all entries collected so far, resetting the capture to an empty state.</summary>
+    public void Clear() => captured.Clear();
+
+    /// <summary>
+    ///     Returns the number of captured messages at the given <paramref name="logLevel" />.
+    /// </summary>
+    /// <param name="logLevel">The severity level to count.</param>
+    /// <returns>The number of captured messages matching <paramref name="logLevel" />.</returns>
+    public int Count(LogLevel logLevel) => captured.Count(e => e.Level == logLevel);
+
+    /// <summary>
+    ///     Returns all captured entries at the given <paramref name="logLevel" />, in the order they were received.
+    /// </summary>
+    /// <param name="logLevel">The severity level to filter by.</param>
+    /// <returns>All captured <see cref="LogEntry" /> instances matching <paramref name="logLevel" />.</returns>
+    public IReadOnlyList<LogEntry> EntriesOf(LogLevel logLevel)
+        => [.. captured.Where(e => e.Level == logLevel)];
+
+    /// <summary>Returns all active captures watching <paramref name="type" />.</summary>
+    /// <param name="type">The type to look up.</param>
+    /// <returns>All active <see cref="LogCapture" /> instances watching <paramref name="type" />.</returns>
+    internal static IEnumerable<LogCapture> GetCaptures(Type type)
+        => Registry.TryGetValue(type, out var captures) ? captures.Keys : [];
+
+    /// <summary>Records a single log entry. Called by <see cref="TypedLogger" />.</summary>
+    /// <param name="level">The severity level.</param>
+    /// <param name="message">The message text.</param>
+    /// <param name="source">The class that emitted the message.</param>
+    internal void Capture(LogLevel level, string message, Type source)
+        => captured.Enqueue(new LogEntry(level, message, source));
+}

--- a/Api/src/api/LogEntry.cs
+++ b/Api/src/api/LogEntry.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Api;
+
+/// <summary>A single log entry captured by <see cref="LogCapture" />.</summary>
+/// <param name="Level">The severity level of the message.</param>
+/// <param name="Message">The message text.</param>
+/// <param name="Source">The class that emitted the message.</param>
+public sealed record LogEntry(LogLevel Level, string Message, Type Source);

--- a/Api/src/api/LogLevel.cs
+++ b/Api/src/api/LogLevel.cs
@@ -20,5 +20,10 @@ public enum LogLevel
     /// <summary>
     ///     Error message.
     /// </summary>
-    Error = 2
+    Error = 2,
+
+    /// <summary>
+    ///     Debug message. Only emitted in DEBUG builds via <see cref="ITestEngineLogger.LogDebug" />.
+    /// </summary>
+    Debug = 3
 }

--- a/Api/src/api/LoggerFactory.cs
+++ b/Api/src/api/LoggerFactory.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Api;
+
+using Core.Logging;
+
+/// <summary>
+///     Factory for obtaining class-scoped loggers that integrate with <see cref="LogCapture" />.
+/// </summary>
+/// <remarks>
+///     Obtain a scoped logger in any class:
+///     <code>
+///     private static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger&lt;MyClass&gt;();
+///     </code>
+///     Log messages are forwarded to any active <see cref="LogCapture" /> scopes watching that class,
+///     and to the global engine logger.
+/// </remarks>
+public static class LoggerFactory
+{
+    /// <summary>
+    ///     Returns a class-scoped logger for <typeparamref name="T" />.
+    ///     Log messages are forwarded to any active <see cref="LogCapture" /> scopes registered for
+    ///     <typeparamref name="T" /> and to the global logger.
+    /// </summary>
+    /// <typeparam name="T">The class the logger is associated with.</typeparam>
+    /// <returns>A class-scoped <see cref="ITestEngineLogger" /> for <typeparamref name="T" />.</returns>
+    public static ITestEngineLogger GetLogger<T>() => new TypedLogger(typeof(T));
+
+    /// <summary>
+    ///     Returns a class-scoped logger for <paramref name="type" />.
+    /// </summary>
+    /// <param name="type">The class the logger is associated with.</param>
+    /// <returns>A class-scoped <see cref="ITestEngineLogger" /> for <paramref name="type" />.</returns>
+    public static ITestEngineLogger GetLogger(Type type) => new TypedLogger(type);
+}

--- a/Api/src/core/GdUnit4TestEngine.cs
+++ b/Api/src/core/GdUnit4TestEngine.cs
@@ -11,6 +11,8 @@ using Discovery;
 
 using Extensions;
 
+using Logging;
+
 using Runners;
 
 internal sealed class GdUnit4TestEngine : ITestEngine
@@ -22,6 +24,7 @@ internal sealed class GdUnit4TestEngine : ITestEngine
     {
         Settings = settings;
         Logger = logger;
+        TestEngineLogger.Register(logger);
     }
 
     private TestEngineSettings Settings { get; }

--- a/Api/src/core/logging/NoOpTestEngineLogger.cs
+++ b/Api/src/core/logging/NoOpTestEngineLogger.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Core.Logging;
+
+using Api;
+
+/// <summary>Discards all log messages. Used as the default logger before one is registered.</summary>
+internal sealed class NoOpTestEngineLogger : ITestEngineLogger
+{
+    internal static readonly NoOpTestEngineLogger Instance = new();
+
+    private NoOpTestEngineLogger()
+    {
+    }
+
+    void ITestEngineLogger.SendMessage(LogLevel logLevel, string message)
+    {
+    }
+}

--- a/Api/src/core/logging/TestEngineLogger.cs
+++ b/Api/src/core/logging/TestEngineLogger.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Core.Logging;
+
+using Api;
+
+/// <summary>
+///     Manages the global logger instance used by all class-scoped loggers.
+///     Intended for engine-internal use only; use <see cref="LoggerFactory" /> to obtain loggers.
+/// </summary>
+/// <remarks>
+///     Register the real logger once at engine startup:
+///     <code>
+///     TestEngineLogger.Register(myLogger);
+///     </code>
+/// </remarks>
+internal static class TestEngineLogger
+{
+    private static volatile ITestEngineLogger global = NoOpTestEngineLogger.Instance;
+
+    /// <summary>Gets the currently registered global logger.</summary>
+    internal static ITestEngineLogger Global => global;
+
+    /// <summary>
+    ///     Registers the global logger used as the fallback for all class-scoped loggers.
+    ///     Intended to be called once at engine startup.
+    /// </summary>
+    /// <param name="logger">The logger implementation to register.</param>
+    internal static void Register(ITestEngineLogger logger)
+        => global = logger ?? throw new ArgumentNullException(nameof(logger));
+}

--- a/Api/src/core/logging/TypedLogger.cs
+++ b/Api/src/core/logging/TypedLogger.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Core.Logging;
+
+using System;
+
+using Api;
+
+/// <summary>
+///     An <see cref="ITestEngineLogger" /> that routes messages to active <see cref="LogCapture" /> scopes
+///     registered for its type, and forwards all messages to the global logger.
+/// </summary>
+internal sealed class TypedLogger(Type type) : ITestEngineLogger
+{
+    void ITestEngineLogger.SendMessage(LogLevel logLevel, string message)
+    {
+        foreach (var capture in LogCapture.GetCaptures(type))
+            capture.Capture(logLevel, message, type);
+
+        switch (logLevel)
+        {
+            case LogLevel.Debug:
+                TestEngineLogger.Global.LogDebug(message);
+                break;
+            case LogLevel.Informational:
+                TestEngineLogger.Global.LogInfo(message);
+                break;
+            case LogLevel.Warning:
+                TestEngineLogger.Global.LogWarning(message);
+                break;
+            case LogLevel.Error:
+                TestEngineLogger.Global.LogError(message);
+                break;
+            default:
+                TestEngineLogger.Global.LogInfo(message);
+                break;
+        }
+    }
+}

--- a/Api/src/core/runners/GodotLogger.cs
+++ b/Api/src/core/runners/GodotLogger.cs
@@ -14,6 +14,9 @@ internal sealed class GodotLogger : ITestEngineLogger
     {
         switch (logLevel)
         {
+            case LogLevel.Debug:
+                GD.PrintS("[DEBUG]:", message);
+                break;
             case LogLevel.Informational:
                 GD.PrintS(message);
                 break;

--- a/Api/src/core/testExtensions/ExtensionRegistry.cs
+++ b/Api/src/core/testExtensions/ExtensionRegistry.cs
@@ -9,10 +9,13 @@ using Api;
 
 internal sealed class ExtensionRegistry
 {
+    private static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<ExtensionRegistry>();
+
     private readonly List<ITestExtension> extensions = [];
 
     public ReadOnlyCollection<ITestExtension> FindTestExtensions(Type type)
     {
+        Logger.LogDebug($"Scanning test suite '{type.FullName}' for registered test extensions.");
         extensions.Clear();
         extensions.AddRange(CollectExtendWithExtensions(type));
         extensions.AddRange(CollectRegisterExtensions(type));

--- a/TestAdapter/src/utilities/Logger.cs
+++ b/TestAdapter/src/utilities/Logger.cs
@@ -33,11 +33,15 @@ public class Logger : ITestEngineLogger
 
     /// <summary>
     ///     Sends a message to the VS test platform logger with the appropriate level.
+    ///     Debug-level messages are suppressed as the VS test platform has no equivalent level.
     /// </summary>
     /// <param name="logLevel">The severity level of the message.</param>
     /// <param name="message">The message to log.</param>
     public void SendMessage(LogLevel logLevel, string message)
     {
+        if (logLevel == LogLevel.Debug)
+            return;
+
         if (LevelMap.TryGetValue(logLevel, out var testLogLevel))
             delegator.SendMessage(testLogLevel, $"[GdUnit4] {message}");
         else


### PR DESCRIPTION
# Why

There was no centralized way to obtain a logger without propagating
ITestEngineLogger through constructor injection across every component.
Tests also had no built-in mechanism to capture log output and assert on
it — each project had to maintain its own no-op or spy logger.

#  What

* LoggerFactory (public, GdUnit4.Api)

A static factory that lets any class obtain a class-scoped logger without
being part of the injection chain:

```cs
private static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger();
```

* LogCapture (public, GdUnit4.Api)

A test utility that intercepts log messages emitted by specific classes so
tests can assert on them without noise from unrelated components:

```cs
using var capture = LogCapture.Watch();

new OrderService().PlaceOrder(42);

AssertThat(capture.Entries).ContainsExactly(
    new LogEntry(LogLevel.Informational, "Order 42 placed", typeof(OrderService)),
    new LogEntry(LogLevel.Warning,       "Stock running low", typeof(OrderService)));
```