### PR TITLE
GD-428: Fix CI-PR workflow by granting actions:write permission to reusable workflow

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ci-pr-${{ github.event.number }}
   cancel-in-progress: true
 
+permissions:
+  actions: write
+  contents: read
 
 jobs:
 


### PR DESCRIPTION
# Why                                                                                                                                                                                                                                                                                                       
When a reusable workflow (unit-tests.yml) is called from ci-pr.yml, GitHub's permission model caps the called workflow's GITHUB_TOKEN to what the caller explicitly grants. 

Without a permissions block in ci-pr.yml, GitHub enforces actions: none for the nested job, causing the unit-test-runner job  
(which requires actions: write for the gdUnit4-action retry/cancel mechanism) to fail with:                                                                                                                                                                                                                 
▎ "The nested job 'unit-test-runner' is requesting 'actions: write', but is only allowed 'actions: none'."
                                                                                                                                                                                                                                                                                                            
# What                                                                                                                                                                                                                                                                                                      
Add a top-level permissions block to ci-pr.yml granting actions: write and contents: read, so all jobs in the workflow — including those delegating to reusable workflows — receive the necessary permissions. 