### PR TITLE
GD-400: Cleanup IExtensionContext

### DIFF
--- a/Api.Test/src/core/testExtensions/ExtensionContextTest.cs
+++ b/Api.Test/src/core/testExtensions/ExtensionContextTest.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using GdUnit4.Api;
 using GdUnit4.Core.TestExtensions;
 using static GdUnit4.Assertions;
@@ -10,59 +7,26 @@ namespace GdUnit4.Tests.Core.TestExtensions;
 [TestSuite]
 public class ExtensionContextTest
 {
-    private static readonly TestSuiteNode SuiteNode = new()
-    {
-        ManagedType = typeof(ExtensionContextTest).FullName ?? "",
-        Tests = [],
-        AssemblyPath = "test.dll",
-        SourceFile = "ExtensionContextTest.cs",
-        Id = Guid.NewGuid(),
-        ParentId = Guid.NewGuid()
-    };
+    private static IExtensionContext CreateSuiteContext() => new ExtensionContext();
 
-    private static MethodInfo GetMethod(string name) =>
-        typeof(ExtensionContextTest).GetMethod(name)
-            ?? throw new InvalidOperationException($"Method '{name}' not found");
-
-    private static IExtensionContext CreateSuiteContext() =>
-        new ExtensionContext(typeof(ExtensionContextTest), SuiteNode);
-
-    private static IExtensionContext CreateTestContext(IExtensionContext parent, string methodName, List<object?> args) =>
-        new ExtensionContext(parent, GetMethod(methodName), methodName, args);
+    private static IExtensionContext CreateTestContext(IExtensionContext parent) => new ExtensionContext(parent);
 
     [TestCase]
     public void TestConstructorAtSuiteLevel()
     {
         var context = CreateSuiteContext();
-        AssertThat(context.GetTestSuiteType()).IsEqual(typeof(ExtensionContextTest));
-        AssertThat(context.GetTestSuiteInstance()).IsEqual(SuiteNode);
-        AssertObject(context.GetTestMethod()).IsNull();
-        AssertObject(context.GetTestCaseName()).IsNull();
-        AssertObject(context.GetTestCaseArguments()).IsNull();
         AssertObject(context.GetStore()).IsNotNull();
         AssertInt(context.GetStore().Count()).IsEqual(0);
     }
-
 
     [TestCase]
     public void TestConstructorAtTestLevel()
     {
         var suite = CreateSuiteContext();
-        var test = CreateTestContext(suite, nameof(TestConstructorAtTestLevel), []);
-        AssertThat(test.GetTestSuiteType()).IsEqual(typeof(ExtensionContextTest));
-        AssertThat(test.GetTestSuiteInstance()).IsEqual(SuiteNode);
-        AssertThat(test.GetTestMethod()).IsEqual(GetMethod(nameof(TestConstructorAtTestLevel)));
-        AssertString(test.GetTestCaseName()).IsEqual(nameof(TestConstructorAtTestLevel));
-        AssertThat(test.GetTestCaseArguments()).IsNotNull();
-        AssertInt(test.GetTestCaseArguments()!.Count).IsEqual(0);
+        var test = CreateTestContext(suite);
         
         suite.GetStore().Add("key", "suite-value");
+        
         AssertString(test.GetStore().Value<string>("key")).IsEqual("suite-value");
-        
-        
-        List<object?> args = ["hello", 42, null];
-        var argsTest = CreateTestContext(suite, nameof(TestConstructorAtTestLevel), args);
-        AssertThat(argsTest.GetTestCaseArguments()).IsNotNull();
-        AssertThat(argsTest.GetTestCaseArguments()!).ContainsExactly("hello", 42, null);
     }
 }

--- a/Api.Test/src/core/testExtensions/ExtensionRegistryTest.cs
+++ b/Api.Test/src/core/testExtensions/ExtensionRegistryTest.cs
@@ -168,17 +168,7 @@ public class ExtensionRegistryTest
     {
         extensionRegistry.FindTestExtensions(typeof(SuiteWithExtensionsInherits));
         
-        var context = new ExtensionContext(
-            typeof(SuiteWithExtensionsInherits),
-            new TestSuiteNode
-            {
-                ManagedType = "null",
-                Tests = [],
-                AssemblyPath = "null",
-                SourceFile = "null",
-                Id = Guid.NewGuid(),
-                ParentId = Guid.NewGuid()
-            });
+        var context = new ExtensionContext();
         
         await extensionRegistry.RunBeforeAll(context);
         
@@ -198,24 +188,9 @@ public class ExtensionRegistryTest
         var testMethod = testSuiteType.GetMethod(nameof(SuiteWithExtensionsInherits.TestMethod))!;
         extensionRegistry.FindTestExtensions(testSuiteType);
         
-        var suiteContext = new ExtensionContext(
-            testSuiteType,
-            new TestSuiteNode
-            {
-                ManagedType = "null",
-                Tests = [],
-                AssemblyPath = "null",
-                SourceFile = "null",
-                Id = Guid.NewGuid(),
-                ParentId = Guid.NewGuid()
-            });
+        var suiteContext = new ExtensionContext();
 
-        var testContext = new ExtensionContext(
-            suiteContext,
-            testMethod,
-            testMethod.Name,
-            []
-        );
+        var testContext = new ExtensionContext(suiteContext);
         
         await extensionRegistry.RunBeforeEach(testContext);
         
@@ -235,24 +210,9 @@ public class ExtensionRegistryTest
         var testMethod = testSuiteType.GetMethod(nameof(SuiteWithExtensionsInherits.TestMethod))!;
         extensionRegistry.FindTestExtensions(testSuiteType);
         
-        var suiteContext = new ExtensionContext(
-            testSuiteType,
-            new TestSuiteNode
-            {
-                ManagedType = "null",
-                Tests = [],
-                AssemblyPath = "null",
-                SourceFile = "null",
-                Id = Guid.NewGuid(),
-                ParentId = Guid.NewGuid()
-            });
+        var suiteContext = new ExtensionContext();
 
-        var testContext = new ExtensionContext(
-            suiteContext,
-            testMethod,
-            testMethod.Name,
-            []
-        );
+        var testContext = new ExtensionContext(suiteContext);
         
         await extensionRegistry.RunAfterEach(testContext);
         
@@ -269,18 +229,8 @@ public class ExtensionRegistryTest
     public async Task RunAfterAll_ShouldExecuteExtensionsInReverseOrder()
     {
         extensionRegistry.FindTestExtensions(typeof(SuiteWithExtensionsInherits));
-        
-        var suiteContext = new ExtensionContext(
-            typeof(SuiteWithExtensionsInherits),
-            new TestSuiteNode
-            {
-                ManagedType = "null",
-                Tests = [],
-                AssemblyPath = "null",
-                SourceFile = "null",
-                Id = Guid.NewGuid(),
-                ParentId = Guid.NewGuid()
-            });
+
+        var suiteContext = new ExtensionContext();
         
         await extensionRegistry.RunAfterAll(suiteContext);
         

--- a/Api/src/api/IExtensionContext.cs
+++ b/Api/src/api/IExtensionContext.cs
@@ -2,38 +2,11 @@
 // MIT License - See LICENSE file in the repository root for full license text
 namespace GdUnit4.Api;
 
-using System.Collections.ObjectModel;
-using System.Reflection;
-
 /// <summary>
 /// Provides context information to test extensions during their lifecycle callbacks.
 /// </summary>
 public interface IExtensionContext
 {
-    /// <summary>Gets the test suite class being executed.</summary>
-    /// <returns>The test suite class being executed.</returns>
-    Type GetTestSuiteType();
-
-    /// <summary>Gets the live instance of the test suite.</summary>
-    /// <returns>The instance of the test suite bing executed.</returns>
-    TestSuiteNode? GetTestSuiteInstance();
-
-    /// <summary>Gets the test method currently executing (null during suite-level callbacks).</summary>
-    /// <returns>The test method current executing, or null during suite-level callbacks.</returns>
-    MethodInfo? GetTestMethod();
-
-    /// <summary>Gets display name of the current test case, or null at suite level.</summary>
-    /// <returns>Gets the display name of the current est case, or null during suite-level callbacks.</returns>
-    string? GetTestCaseName();
-
-    /// <summary>
-    /// Gets the raw arguments passed to [TestCase(...)].
-    /// Extensions read these in BeforeEach to configure themselves per test.
-    /// Arguments not consumed by parameter resolvers are available here.
-    /// </summary>
-    /// <returns>Arguments to the test case method that have not been consumed by parameter resolvers.</returns>
-    ReadOnlyCollection<object?>? GetTestCaseArguments();
-
     /// <summary>
     /// Get the parameter store for this extension context, which allows extensions to store and retrieve arbitrary
     /// values within the context of test execution. This is useful for sharing state between different lifecycle

--- a/Api/src/core/commands/ExecuteTestSuiteCommand.cs
+++ b/Api/src/core/commands/ExecuteTestSuiteCommand.cs
@@ -65,7 +65,7 @@ internal class ExecuteTestSuiteCommand : BaseCommand
 
                 var extensionRegistry = new ExtensionRegistry();
                 _ = extensionRegistry.FindTestExtensions(testSuite.Instance.GetType());
-                var extensionContext = new ExtensionContext(testSuite.Instance.GetType());
+                var extensionContext = new ExtensionContext();
                 using ExecutionContext context = new(
                     testSuite,
                     [testEventListener],

--- a/Api/src/core/execution/TestSuiteExecutionStage.cs
+++ b/Api/src/core/execution/TestSuiteExecutionStage.cs
@@ -46,11 +46,7 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
         {
             foreach (var testCase in testSuiteContext.TestSuite.TestCases)
             {
-                var extensionContext = new ExtensionContext(
-                    testSuiteContext.ExtensionContext,
-                    testCase.MethodInfo,
-                    testCase.Name,
-                    [.. testCase.Arguments]);
+                var extensionContext = new ExtensionContext(testSuiteContext.ExtensionContext);
                 using var testCaseContext = new ExecutionContext(testSuiteContext, extensionContext, testCase);
                 if (testCase.HasDataPoint)
                 {
@@ -94,11 +90,7 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
                     await foreach (var dataPointValues in DataPointValueProvider.GetDataAsync(testCase, timeout).ConfigureAwait(false))
                     {
                         var displayName = TestCase.BuildDisplayName(testCase.Name, new TestCaseAttribute(dataPointValues));
-                        var extensionContext = new ExtensionContext(
-                            executionContext.ExtensionContext,
-                            executionContext.CurrentTestCase?.MethodInfo!,
-                            executionContext.TestCaseName,
-                            [.. dataPointValues]);
+                        var extensionContext = new ExtensionContext(executionContext.ExtensionContext);
                         using ExecutionContext testCaseContext = new(executionContext, extensionContext, displayName);
                         await RunTestCase(stdoutHook, testCaseContext, testCase, testAttribute, dataPointValues)
                             .ConfigureAwait(true);
@@ -122,11 +114,7 @@ internal sealed class TestSuiteExecutionStage : IExecutionStage
                 foreach (var dataPointValues in DataPointValueProvider.GetData(testCase))
                 {
                     var displayName = TestCase.BuildDisplayName(testCase.Name, new TestCaseAttribute(dataPointValues));
-                    var extensionContext = new ExtensionContext(
-                        executionContext.ExtensionContext,
-                        executionContext.CurrentTestCase?.MethodInfo!,
-                        executionContext.TestCaseName,
-                        [.. dataPointValues]);
+                    var extensionContext = new ExtensionContext(executionContext.ExtensionContext);
                     using ExecutionContext testCaseContext = new(executionContext, extensionContext, displayName);
                     await RunTestCase(stdoutHook, testCaseContext, testCase, testAttribute, dataPointValues)
                         .ConfigureAwait(true);

--- a/Api/src/core/testExtensions/ExtensionContext.cs
+++ b/Api/src/core/testExtensions/ExtensionContext.cs
@@ -2,54 +2,15 @@
 // MIT License - See LICENSE file in the repository root for full license text
 namespace GdUnit4.Core.TestExtensions;
 
-using System.Collections.ObjectModel;
-using System.Reflection;
-
 using Api;
 
 internal class ExtensionContext : IExtensionContext
 {
-    private readonly Type testSuiteType;
-
-    private readonly TestSuiteNode? testSuiteInstance;
-
-    private readonly MethodInfo? testMethod;
-
     private readonly IParameterStore parameterStore;
 
-    private readonly string? testCaseName;
+    public ExtensionContext(IExtensionContext parentContext) => parameterStore = new ParameterStore(parentContext.GetStore());
 
-    private readonly ReadOnlyCollection<object?>? testCaseArguments;
-
-    public ExtensionContext(IExtensionContext parentContext, MethodInfo testMethod, string testCaseName, List<object?> testCaseArguments)
-    {
-        parameterStore = new ParameterStore(parentContext.GetStore());
-        testSuiteType = parentContext.GetTestSuiteType();
-        testSuiteInstance = parentContext.GetTestSuiteInstance();
-        this.testMethod = testMethod;
-        this.testCaseName = testCaseName;
-        this.testCaseArguments = new ReadOnlyCollection<object?>(testCaseArguments);
-    }
-
-    public ExtensionContext(Type testSuiteType, TestSuiteNode? testSuiteInstance = null)
-    {
-        parameterStore = new ParameterStore();
-        this.testSuiteType = testSuiteType;
-        this.testSuiteInstance = testSuiteInstance;
-        testMethod = null;
-        testCaseName = null;
-        testCaseArguments = null;
-    }
-
-    public Type GetTestSuiteType() => testSuiteType;
-
-    public TestSuiteNode? GetTestSuiteInstance() => testSuiteInstance;
-
-    public MethodInfo? GetTestMethod() => testMethod;
-
-    public string? GetTestCaseName() => testCaseName;
-
-    public ReadOnlyCollection<object?>? GetTestCaseArguments() => testCaseArguments;
+    public ExtensionContext() => parameterStore = new ParameterStore();
 
     public IParameterStore GetStore() => parameterStore;
 }


### PR DESCRIPTION
# Why

Reduce the footprint of this class to as little as possible

# What

Remove everything but the `GetStore` method as well as all references and implementations.