### PR TITLE
GD-437: Respect CompileProcessTimeout in dotnet build step

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -201,10 +201,10 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        gdunit-version: [ 'v5.1.1' ]
-        godot-version: [ '4.3', '4.4', '4.4.1' ]
-        godot-status: [ 'stable' ]
-        dotnet-version: [ 'net9.0' ]
+        gdunit-version: ['v5.1.1']
+        godot-version: ['4.3', '4.4', '4.4.1']
+        godot-status: ['stable']
+        dotnet-version: ['net9.0']
         include:
           # Latest
           - gdunit-version: 'latest'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ci-pr-${{ github.event.number }}
   cancel-in-progress: true
 
+permissions:
+  actions: write
+  contents: read
 
 jobs:
 
@@ -198,10 +201,10 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        gdunit-version: ['v5.1.1']
-        godot-version: ['4.3', '4.4', '4.4.1']
-        godot-status: ['stable']
-        dotnet-version: ['net9.0']
+        gdunit-version: [ 'v5.1.1' ]
+        godot-version: [ '4.3', '4.4', '4.4.1' ]
+        godot-status: [ 'stable' ]
+        dotnet-version: [ 'net9.0' ]
         include:
           # Latest
           - gdunit-version: 'latest'

--- a/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
+++ b/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
@@ -209,7 +209,7 @@ public class GodotRuntimeTestRunnerTest
     public void TestInstallTestRunnerSuccess()
     {
         // Create a separate temp working directory
-        var workingDirectory = Path.Combine(Environment.CurrentDirectory, @"..\TestExample");
+        var workingDirectory = Path.Combine(Environment.CurrentDirectory, "../TestExample");
 
         try
         {
@@ -241,7 +241,7 @@ public class GodotRuntimeTestRunnerTest
     public void TestInstallTestRunnerFailsByBuildTimeout()
     {
         // Create a separate temp working directory
-        var workingDirectory = Path.Combine(Environment.CurrentDirectory, @"..\TestExample");
+        var workingDirectory = Path.Combine(Environment.CurrentDirectory, "../TestExample");
 
         try
         {
@@ -270,7 +270,7 @@ public class GodotRuntimeTestRunnerTest
 
     private static void CopyExampleProject(string destDir)
     {
-        var sourceDir = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, @"..\Example"));
+        var sourceDir = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, "../Example"));
         Directory.CreateDirectory(destDir);
         var files = Directory.GetFiles(sourceDir, "*.*", SearchOption.AllDirectories);
 

--- a/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
+++ b/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
@@ -50,10 +50,10 @@ public class GodotRuntimeTestRunnerTest
         DebuggerFrameworkMock = new Mock<IDebuggerFramework>();
     }
 
-    private GodotRuntimeTestRunner CreateTestRunner(int timeout) => new(
+    private GodotRuntimeTestRunner CreateTestRunner(int compileTimeout) => new(
         LoggerMock.Object,
         DebuggerFrameworkMock.Object,
-        new TestEngineSettings { CompileProcessTimeout = timeout });
+        new TestEngineSettings { CompileProcessTimeout = compileTimeout });
 
     /// <summary>
     ///     Clean up after tests
@@ -209,25 +209,82 @@ public class GodotRuntimeTestRunnerTest
     public void TestInstallTestRunnerSuccess()
     {
         // Create a separate temp working directory
-        var workingDirectory = Path.Combine(TestTempDirectory!, "working_dir_failure");
-        Directory.CreateDirectory(workingDirectory);
+        var workingDirectory = Path.Combine(Environment.CurrentDirectory, @"..\TestExample");
 
-        // Act
-        var result = CreateTestRunner(1000).InstallTestRunnerClasses(workingDirectory, false);
+        try
+        {
+            // Copy Example Project into working directory
+            CopyExampleProject(workingDirectory);
 
-        // Assert
-        AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should return true").IsTrue();
+            // Act
+            var result = CreateTestRunner(30000).InstallTestRunnerClasses(workingDirectory);
 
-        // Verify error message was logged
-        VerifyLoggerInfo("Installing GdUnit4TestRunnerScene at");
+            // Assert
+            AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should return true").IsTrue();
 
-        // Verify the runner file was created in the correct location
-        var runnerPath = Path.Combine(workingDirectory, GodotRuntimeTestRunner.TEMP_TEST_RUNNER_DIR, "GdUnit4TestRunnerScene.cs");
-        AssertThat(File.Exists(runnerPath)).OverrideFailureMessage($"Runner file should exist at {runnerPath}").IsTrue();
+            // Verify log message
+            VerifyLoggerInfo("Installing GdUnit4TestRunnerScene at");
+            VerifyLoggerInfo("dotnet build completed successfully");
+
+            // Verify the runner file was created in the correct location
+            var runnerPath = Path.Combine(workingDirectory, GodotRuntimeTestRunner.TEMP_TEST_RUNNER_DIR, "GdUnit4TestRunnerScene.cs");
+            AssertThat(File.Exists(runnerPath)).OverrideFailureMessage($"Runner file should exist at {runnerPath}").IsTrue();
+        }
+        finally
+        {
+            // Cleanup
+            Directory.Delete(workingDirectory, true);
+        }
     }
 
+    [TestCase]
+    public void TestInstallTestRunnerFailsByBuildTimeout()
+    {
+        // Create a separate temp working directory
+        var workingDirectory = Path.Combine(Environment.CurrentDirectory, @"..\TestExample");
+
+        try
+        {
+            // Copy Example Project into working directory
+            CopyExampleProject(workingDirectory);
+
+            // Act
+            var result = CreateTestRunner(1000).InstallTestRunnerClasses(workingDirectory);
+
+            // Assert
+            AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should fail").IsFalse();
+
+            VerifyLoggerInfo("Installing GdUnit4TestRunnerScene at");
+            // Verify error messages
+            VerifyLoggerError("`dotnet build` did not complete within the configured timeout of 1000ms.");
+            VerifyLoggerError("dotnet build failed with exit code:");
+        }
+        finally
+        {
+            // Cleanup
+            Directory.Delete(workingDirectory, true);
+        }
+    }
 
     #region Helper Methods
+
+    private static void CopyExampleProject(string destDir)
+    {
+        var sourceDir = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, @"..\Example"));
+        Directory.CreateDirectory(destDir);
+        var files = Directory.GetFiles(sourceDir, "*.*", SearchOption.AllDirectories);
+
+        foreach (var file in files)
+        {
+            var relativePath = Path.GetRelativePath(sourceDir, file);
+            if (relativePath.StartsWith(".godot") || relativePath.StartsWith("gdunit4_testadapter_v5"))
+                continue;
+
+            var destFile = Path.Combine(destDir, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(destFile));
+            File.Copy(file, destFile, true);
+        }
+    }
 
     /// <summary>
     ///     Create a script that succeeds quickly
@@ -416,9 +473,9 @@ public class GodotRuntimeTestRunnerTest
                 .Select(i => i.Arguments[0]?.ToString() ?? "null")
                 .ToList();
 
-            var message = $"Expected error message containing '{expectedText}' was not found.\n\n" +
-                          $"Actual LogError calls ({invocations.Count}):\n" +
-                          string.Join("\n", invocations.Select((msg, i) => $"  {i + 1}. {msg}"));
+            var message = $"Expected error message containing \n'{expectedText}'\n was not found.\n\n" +
+                          $"Actual Error entries ({invocations.Count}):\n" +
+                          string.Join("\n", invocations.Select((msg, i) => $"'{msg}'"));
 
             AssertBool(true).OverrideFailureMessage(message).IsFalse();
         }

--- a/Api/src/core/runners/GodotRuntimeTestRunner.cs
+++ b/Api/src/core/runners/GodotRuntimeTestRunner.cs
@@ -396,14 +396,13 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
         try
         {
             Logger.LogInfo("Running dotnet build to ensure dependencies are available...");
-            var arguments = "build --configuration Debug "
-                            + "--verbosity normal "
-                            + "--no-restore "
-                            + "/p:BuildProjectReferences=false " // Don't rebuild project refs
-                            + "/p:_GetChildProjectCopyToOutputDirectoryItems=false " // Don't copy child project items
-                            + "/p:SkipCopyingFrameworkReferences=true " // Skip framework refs (already present)
-                            + "/p:EnforceCodeStyleInBuild=false "
-                            + "/p:TreatWarningsAsErrors=false ";
+            const string arguments = "build --configuration Debug "
+                                     + "--verbosity normal "
+                                     + "/p:BuildProjectReferences=false " // Don't rebuild project refs
+                                     + "/p:_GetChildProjectCopyToOutputDirectoryItems=false " // Don't copy child project items
+                                     + "/p:SkipCopyingFrameworkReferences=true " // Skip framework refs (already present)
+                                     + "/p:EnforceCodeStyleInBuild=false "
+                                     + "/p:TreatWarningsAsErrors=false ";
             var processStartInfo = new ProcessStartInfo("dotnet", arguments)
             {
                 RedirectStandardOutput = true,
@@ -441,21 +440,49 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
             restoreProcess.BeginErrorReadLine();
             restoreProcess.BeginOutputReadLine();
 
-            // Wait for restore to complete (should be quick)
-            var completed = restoreProcess.WaitForExit(30000); // 30 second timeout
+            // The rebuild project can take a while, and we need to wait until it finishes
+            // Calculate how many iterations we need based on the compile process timeout
+            const int checkIntervalMs = 100; // Check every 100ms
+            var maxRetries = settings.CompileProcessTimeout / checkIntervalMs;
 
-            if (!completed)
+            var waitRetry = 0;
+            while (!restoreProcess.HasExited && waitRetry++ < maxRetries)
+                Thread.Sleep(checkIntervalMs);
+
+            // If the process has not finished within the timeout period, we kill it manually
+            if (!restoreProcess.HasExited)
             {
-                Logger.LogWarning("dotnet build timed out after 30 seconds");
+                Logger.LogError(
+                    $"""
+
+                     ╔═══════════════════════ dotnet build TIMEOUT ═════════════════════════════════════════════════════════════════════════╗
+
+                       `dotnet build` did not complete within the configured timeout of {settings.CompileProcessTimeout}ms.
+
+                       Possible reasons:
+                       - Your project may be large or complex, requiring more time to build
+                       - Your system may be under heavy load or has limited resources
+
+                       ACTION REQUIRED:
+                       To increase the compilation timeout, set the 'CompileProcessTimeout' property in your GdUnit4 settings.
+
+                       Add or modify the following in your .runsettings file:
+                       <GdUnit4>
+                           <CompileProcessTimeout>60000</CompileProcessTimeout>  <!-- 60 seconds -->
+                       </GdUnit4>
+
+                       The process will now be forcefully terminated, which may result in incomplete compilation.
+
+                     ╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝
+                     """);
+
                 restoreProcess.Kill(true);
-                return false;
             }
 
-            var success = restoreProcess.ExitCode == 0;
-            if (success)
+            if (restoreProcess.ExitCode == 0)
             {
                 Logger.LogInfo("dotnet build completed successfully");
-                return success;
+                return true;
             }
 
             Logger.LogError($"dotnet build failed with exit code: {restoreProcess.ExitCode}");

--- a/Api/src/core/runners/GodotRuntimeTestRunner.cs
+++ b/Api/src/core/runners/GodotRuntimeTestRunner.cs
@@ -477,6 +477,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
                      """);
 
                 restoreProcess.Kill(true);
+                _ = restoreProcess.WaitForExit(5000);
             }
 
             if (restoreProcess.ExitCode == 0)


### PR DESCRIPTION
#  Why

The dotnet build step in RunDotnetRestore used a hardcoded 30-second timeout regardless of the user-configured CompileProcessTimeout setting. On timeout it silently returned false with only a warning, giving no actionable guidance. Additionally, --no-restore was skipping package restoration, causing
 failures in clean/CI environments.

#  What

- Removed --no-restore from dotnet build arguments so packages are restored as part of the build
- Replaced the hardcoded WaitForExit(30000) with a polling loop driven by settings.CompileProcessTimeout, consistent with ReCompileGodotProject
- On timeout: kill the process, log a detailed error box with the configured timeout value and instructions to increase it, then fall through to the exit-code check
- Updated TestInstallTestRunnerSuccess from a stub test (reCompile: false) to a real integration test that copies the Example project and runs an actual dotnet build
- Added TestInstallTestRunnerFailsByBuildTimeout to cover the timeout path with platform-safe exit code assertion
