### PR TITLE
GD-426: Add ambient LoggerFactory and LogCapture for testing (#427)

### DIFF
--- a/Api.Test/src/core/logging/LogCaptureTest.cs
+++ b/Api.Test/src/core/logging/LogCaptureTest.cs
@@ -1,0 +1,364 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+using static GdUnit4.Assertions;
+
+namespace GdUnit4.Tests.Core.Logging;
+
+using Api;
+
+[TestSuite]
+public class LogCaptureTest
+{
+    #region Log-source stubs
+
+    // Each class owns its logger, mirroring real production code.
+    private class SourceA
+    {
+        internal static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<SourceA>();
+    }
+
+    private class SourceB
+    {
+        internal static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<SourceB>();
+    }
+
+    private class SourceC
+    {
+        internal static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<SourceC>();
+    }
+
+    #endregion
+
+    #region Watch
+
+    [TestCase]
+    public void Watch_SingleType_CapturesMessagesForThatType()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("hello");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "hello", typeof(SourceA)));
+    }
+
+    [TestCase]
+    public void Watch_DoesNotCaptureMessagesForUnregisteredType()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceB.Logger.LogInfo("unrelated");
+
+        AssertThat(capture.Entries).IsEmpty();
+    }
+
+    [TestCase]
+    public void Watch_TwoTypes_CapturesBothSources()
+    {
+        using var capture = LogCapture.Watch<SourceA, SourceB>();
+
+        SourceA.Logger.LogInfo("from-A");
+        SourceB.Logger.LogInfo("from-B");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(
+                new LogEntry(LogLevel.Informational, "from-A", typeof(SourceA)),
+                new LogEntry(LogLevel.Informational, "from-B", typeof(SourceB)));
+    }
+
+    [TestCase]
+    public void Watch_ThreeTypes_CapturesAllThreeSources()
+    {
+        using var capture = LogCapture.Watch<SourceA, SourceB, SourceC>();
+
+        SourceA.Logger.LogInfo("A");
+        SourceB.Logger.LogInfo("B");
+        SourceC.Logger.LogInfo("C");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(
+                new LogEntry(LogLevel.Informational, "A", typeof(SourceA)),
+                new LogEntry(LogLevel.Informational, "B", typeof(SourceB)),
+                new LogEntry(LogLevel.Informational, "C", typeof(SourceC)));
+    }
+
+    [TestCase]
+    public void Watch_ParamsOverload_CapturesAllSpecifiedTypes()
+    {
+        using var capture = LogCapture.Watch(typeof(SourceA), typeof(SourceB), typeof(SourceC));
+
+        SourceA.Logger.LogInfo("A");
+        SourceB.Logger.LogInfo("B");
+        SourceC.Logger.LogInfo("C");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(
+                new LogEntry(LogLevel.Informational, "A", typeof(SourceA)),
+                new LogEntry(LogLevel.Informational, "B", typeof(SourceB)),
+                new LogEntry(LogLevel.Informational, "C", typeof(SourceC)));
+    }
+
+    #endregion
+
+    #region Dispose
+
+    [TestCase]
+    public void Dispose_RemovesCaptureFromRegistry()
+    {
+        var capture = LogCapture.Watch<SourceA>();
+
+        capture.Dispose();
+
+        AssertThat(LogCapture.GetCaptures(typeof(SourceA))).IsEmpty();
+    }
+
+    [TestCase]
+    public void Dispose_RemovesOnlyTheDisposedCapture_WhenTwoCapturesAreActive()
+    {
+        var captureA = LogCapture.Watch<SourceA>();
+        var captureB = LogCapture.Watch<SourceA>();
+
+        captureA.Dispose();
+
+        AssertThat(LogCapture.GetCaptures(typeof(SourceA)))
+            .ContainsExactly(captureB);
+
+        captureB.Dispose();
+    }
+
+    [TestCase]
+    public void Dispose_StopsCapturingMessages()
+    {
+        LogCapture capture;
+        using (capture = LogCapture.Watch<SourceA>())
+        {
+            SourceA.Logger.LogInfo("inside");
+        }
+
+        SourceA.Logger.LogInfo("outside");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "inside", typeof(SourceA)));
+    }
+
+    [TestCase]
+    public void Dispose_IsIdempotent_DoesNotThrow()
+    {
+        var capture = LogCapture.Watch<SourceA>();
+
+        capture.Dispose();
+        capture.Dispose();
+
+        AssertThat(LogCapture.GetCaptures(typeof(SourceA))).IsEmpty();
+    }
+
+    #endregion
+
+    #region Entries
+
+    [TestCase]
+    public void Entries_ReturnsEntriesInEmissionOrder()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("first");
+        SourceA.Logger.LogWarning("second");
+        SourceA.Logger.LogError("third");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(
+                new LogEntry(LogLevel.Informational, "first", typeof(SourceA)),
+                new LogEntry(LogLevel.Warning, "second", typeof(SourceA)),
+                new LogEntry(LogLevel.Error, "third", typeof(SourceA)));
+    }
+
+    [TestCase]
+    public void Entries_IsEmptyWhenNothingLogged()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        AssertThat(capture.Entries).IsEmpty();
+    }
+
+    #endregion
+
+    #region Clear
+
+    [TestCase]
+    public void Clear_RemovesAllCapturedEntries()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("before");
+        capture.Clear();
+
+        AssertThat(capture.Entries).IsEmpty();
+    }
+
+    [TestCase]
+    public void Clear_AllowsCapturingNewEntriesAfterReset()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("before");
+        capture.Clear();
+        SourceA.Logger.LogInfo("after");
+
+        AssertThat(capture.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "after", typeof(SourceA)));
+    }
+
+    #endregion
+
+    #region Count
+
+    [TestCase]
+    public void Count_ReturnsCorrectCountPerLevel()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("info");
+        SourceA.Logger.LogWarning("warning");
+        SourceA.Logger.LogError("error");
+
+        AssertThat(capture.Count(LogLevel.Informational)).IsEqual(1);
+        AssertThat(capture.Count(LogLevel.Warning)).IsEqual(1);
+        AssertThat(capture.Count(LogLevel.Error)).IsEqual(1);
+    }
+
+    [TestCase]
+    public void Count_ReturnsZeroForLevelWithNoMessages()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("only info");
+
+        AssertThat(capture.Count(LogLevel.Warning)).IsEqual(0);
+        AssertThat(capture.Count(LogLevel.Error)).IsEqual(0);
+    }
+
+    [TestCase]
+    public void Count_AccumulatesAcrossMultipleEmissions()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("a");
+        SourceA.Logger.LogInfo("b");
+        SourceA.Logger.LogInfo("c");
+
+        AssertThat(capture.Count(LogLevel.Informational)).IsEqual(3);
+    }
+
+    #endregion
+
+    #region EntriesOf
+
+    [TestCase]
+    public void EntriesOf_ReturnsOnlyMatchingLevel()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("info");
+        SourceA.Logger.LogWarning("warning");
+        SourceA.Logger.LogError("error");
+
+        AssertThat(capture.EntriesOf(LogLevel.Warning))
+            .ContainsExactly(new LogEntry(LogLevel.Warning, "warning", typeof(SourceA)));
+    }
+
+    [TestCase]
+    public void EntriesOf_ReturnsEmptyListWhenNoneMatch()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("info only");
+
+        AssertThat(capture.EntriesOf(LogLevel.Error)).IsEmpty();
+    }
+
+    [TestCase]
+    public void EntriesOf_RetainsEmissionOrder()
+    {
+        using var capture = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogWarning("w1");
+        SourceA.Logger.LogInfo("skip");
+        SourceA.Logger.LogWarning("w2");
+
+        AssertThat(capture.EntriesOf(LogLevel.Warning))
+            .ContainsExactly(
+                new LogEntry(LogLevel.Warning, "w1", typeof(SourceA)),
+                new LogEntry(LogLevel.Warning, "w2", typeof(SourceA)));
+    }
+
+    #endregion
+
+    #region Parallel captures for the same type
+
+    [TestCase]
+    public void TwoCaptures_ForSameType_BothReceiveMessages()
+    {
+        using var captureA = LogCapture.Watch<SourceA>();
+        using var captureB = LogCapture.Watch<SourceA>();
+
+        SourceA.Logger.LogInfo("shared");
+
+        AssertThat(captureA.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "shared", typeof(SourceA)));
+        AssertThat(captureB.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "shared", typeof(SourceA)));
+    }
+
+    [TestCase]
+    public void DisposingOneCapture_DoesNotAffectOther()
+    {
+        var captureA = LogCapture.Watch<SourceA>();
+        using var captureB = LogCapture.Watch<SourceA>();
+
+        captureA.Dispose();
+        SourceA.Logger.LogInfo("after-dispose");
+
+        AssertThat(captureA.Entries).IsEmpty();
+        AssertThat(captureB.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "after-dispose", typeof(SourceA)));
+    }
+
+    #endregion
+
+    #region LogEntry record
+
+    [TestCase]
+    public void LogEntry_EqualWhenAllFieldsMatch()
+    {
+        var a = new LogEntry(LogLevel.Warning, "oops", typeof(SourceA));
+        var b = new LogEntry(LogLevel.Warning, "oops", typeof(SourceA));
+        AssertThat(a).IsEqual(b);
+    }
+
+    [TestCase]
+    public void LogEntry_NotEqualWhenLevelDiffers()
+    {
+        var a = new LogEntry(LogLevel.Warning, "msg", typeof(SourceA));
+        var b = new LogEntry(LogLevel.Error, "msg", typeof(SourceA));
+        AssertThat(a).IsNotEqual(b);
+    }
+
+    [TestCase]
+    public void LogEntry_NotEqualWhenMessageDiffers()
+    {
+        var a = new LogEntry(LogLevel.Informational, "msg-a", typeof(SourceA));
+        var b = new LogEntry(LogLevel.Informational, "msg-b", typeof(SourceA));
+        AssertThat(a).IsNotEqual(b);
+    }
+
+    [TestCase]
+    public void LogEntry_NotEqualWhenSourceDiffers()
+    {
+        var a = new LogEntry(LogLevel.Informational, "msg", typeof(SourceA));
+        var b = new LogEntry(LogLevel.Informational, "msg", typeof(SourceB));
+        AssertThat(a).IsNotEqual(b);
+    }
+
+    #endregion
+}

--- a/Api.Test/src/core/logging/TypedLoggerTest.cs
+++ b/Api.Test/src/core/logging/TypedLoggerTest.cs
@@ -1,0 +1,120 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+using static GdUnit4.Assertions;
+
+namespace GdUnit4.Tests.Core.Logging;
+
+using System.Collections.Generic;
+
+using Api;
+
+using GdUnit4.Core.Logging;
+
+[TestSuite]
+public class TypedLoggerTest
+{
+    #region Log-source stubs
+
+    // Subject owns its logger, mirroring real production code.
+    private class Subject
+    {
+        // ReSharper disable once UnusedMember.Local
+        internal static readonly ITestEngineLogger _ = LoggerFactory.GetLogger<Subject>();
+    }
+
+    // Records every SendMessage call; used as the backing logger so tests
+    // can verify the level TypedLogger forwards without touching the global logger.
+    private sealed class BackingTestLogger : ITestEngineLogger
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        void ITestEngineLogger.SendMessage(LogLevel logLevel, string message)
+            => Entries.Add(new LogEntry(logLevel, message, typeof(BackingTestLogger)));
+    }
+
+    #endregion
+
+    #region Forwarding without active capture
+
+    [TestCase]
+    public void SendMessage_WithoutCapture_ErrorIsForwardedAtOriginalLevel()
+    {
+        var backingLogger = new BackingTestLogger();
+        ITestEngineLogger logger = new TypedLogger(typeof(Subject), backingLogger);
+
+        logger.LogError("boom");
+
+        AssertThat(backingLogger.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Error, "boom", typeof(BackingTestLogger)));
+    }
+
+    [TestCase]
+    public void SendMessage_WithoutCapture_WarningIsForwardedAtOriginalLevel()
+    {
+        var backingLogger = new BackingTestLogger();
+        ITestEngineLogger logger = new TypedLogger(typeof(Subject), backingLogger);
+
+        logger.LogWarning("caution");
+
+        AssertThat(backingLogger.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Warning, "caution", typeof(BackingTestLogger)));
+    }
+
+    [TestCase]
+    public void SendMessage_WithoutCapture_InformationalIsForwardedAtOriginalLevel()
+    {
+        var backingLogger = new BackingTestLogger();
+        ITestEngineLogger logger = new TypedLogger(typeof(Subject), backingLogger);
+
+        logger.LogInfo("info");
+
+        AssertThat(backingLogger.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "info", typeof(BackingTestLogger)));
+    }
+
+    #endregion
+
+    #region Forwarding with active capture
+
+    [TestCase]
+    public void SendMessage_WithActiveCapture_ErrorIsDemotedToInformationalInBackingLogger()
+    {
+        var backingLogger = new BackingTestLogger();
+        using var capture = LogCapture.Watch<Subject>();
+        ITestEngineLogger logger = new TypedLogger(typeof(Subject), backingLogger);
+
+        logger.LogError("boom");
+
+        AssertThat(backingLogger.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "[Captured Error] boom", typeof(BackingTestLogger)));
+    }
+
+    [TestCase]
+    public void SendMessage_WithActiveCapture_WarningIsDemotedToInformationalInBackingLogger()
+    {
+        var backingLogger = new BackingTestLogger();
+        using var capture = LogCapture.Watch<Subject>();
+        ITestEngineLogger logger = new TypedLogger(typeof(Subject), backingLogger);
+
+        logger.LogWarning("caution");
+
+        AssertThat(backingLogger.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "[Captured Warning] caution", typeof(BackingTestLogger)));
+    }
+
+    [TestCase]
+    public void SendMessage_WithActiveCapture_InformationalIsNotDemotedInBackingLogger()
+    {
+        var backingLogger = new BackingTestLogger();
+        using var capture = LogCapture.Watch<Subject>();
+        ITestEngineLogger logger = new TypedLogger(typeof(Subject), backingLogger);
+
+        logger.LogInfo("info");
+
+        AssertThat(backingLogger.Entries)
+            .ContainsExactly(new LogEntry(LogLevel.Informational, "info", typeof(BackingTestLogger)));
+    }
+
+    #endregion
+}

--- a/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
+++ b/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
@@ -25,7 +25,6 @@ public class GodotRuntimeTestRunnerTest
 
     public required string MockGodotBinPath { get; set; }
     public required Mock<IDebuggerFramework> DebuggerFrameworkMock { get; set; }
-    public required Mock<ITestEngineLogger> LoggerMock { get; set; }
 
 
     /// <summary>
@@ -45,13 +44,10 @@ public class GodotRuntimeTestRunnerTest
             // Unix shell script
             : "mock_godot.sh");
 
-        // Setup mocks
-        LoggerMock = new Mock<ITestEngineLogger>();
         DebuggerFrameworkMock = new Mock<IDebuggerFramework>();
     }
 
     private GodotRuntimeTestRunner CreateTestRunner(int compileTimeout) => new(
-        LoggerMock.Object,
         DebuggerFrameworkMock.Object,
         new TestEngineSettings { CompileProcessTimeout = compileTimeout });
 
@@ -77,12 +73,7 @@ public class GodotRuntimeTestRunnerTest
     }
 
     [AfterTest]
-    public void AfterTest()
-    {
-        // Reset mocks to clear any recorded invocations
-        LoggerMock.Reset();
-        DebuggerFrameworkMock.Reset();
-    }
+    public void AfterTest() => DebuggerFrameworkMock.Reset();
 
     /// <summary>
     ///     Test successful execution of InstallTestRunnerClasses
@@ -97,15 +88,17 @@ public class GodotRuntimeTestRunnerTest
         var workingDirectory = Path.Combine(TestTempDirectory!, "working_dir");
         Directory.CreateDirectory(workingDirectory);
 
+        using var capture = LogCapture.Watch<GodotRuntimeTestRunner>();
+
         // Act
         var result = CreateTestRunner(1000).ReCompileGodotProject(workingDirectory, MockGodotBinPath);
 
         // Assert
-        AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should return true for successful compilation").IsTrue();
+        AssertThat(result).OverrideFailureMessage("ReCompileGodotProject should return true for successful compilation").IsTrue();
 
         // Verify logger was called with success messages
-        VerifyLoggerInfo("Rebuild Godot Project ...");
-        VerifyLoggerInfo("Rebuild Godot Project ends with exit code: 0");
+        AssertLogInfo(capture, "Rebuild Godot Project ...");
+        AssertLogInfo(capture, "Rebuild Godot Project ends with exit code: 0");
     }
 
     /// <summary>
@@ -121,19 +114,21 @@ public class GodotRuntimeTestRunnerTest
         var workingDirectory = Path.Combine(TestTempDirectory!, "working_dir_near_timeout");
         Directory.CreateDirectory(workingDirectory);
 
+        using var capture = LogCapture.Watch<GodotRuntimeTestRunner>();
+
         // Act, Set a longer timeout for this test
         var result = CreateTestRunner(5000).ReCompileGodotProject(workingDirectory, MockGodotBinPath);
 
         // Assert
-        AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should return true for a process that completes just before timeout").IsTrue();
+        AssertThat(result).OverrideFailureMessage("ReCompileGodotProject should return true for a process that completes just before timeout").IsTrue();
 
         // Verify success messages were logged
-        VerifyLoggerInfo("Rebuild Godot Project ...");
-        VerifyLoggerInfo("Rebuild Godot Project ends with exit code: 0");
+        AssertLogInfo(capture, "Rebuild Godot Project ...");
+        AssertLogInfo(capture, "Rebuild Godot Project ends with exit code: 0");
 
         // Verify that no timeout error was logged
-        LoggerMock.Verify(l => l.LogError(It.Is<string>(s =>
-            s.Contains("Godot compilation TIMEOUT"))), Times.Never());
+        AssertThat(capture.EntriesOf(LogLevel.Error).Any(e => e.Message.Contains("Godot compilation TIMEOUT")))
+            .OverrideFailureMessage("Timeout error should not have been logged").IsFalse();
     }
 
     /// <summary>
@@ -149,16 +144,18 @@ public class GodotRuntimeTestRunnerTest
         var workingDirectory = Path.Combine(TestTempDirectory!, "working_dir_timeout");
         Directory.CreateDirectory(workingDirectory);
 
+        using var capture = LogCapture.Watch<GodotRuntimeTestRunner>();
+
         // Act
         var result = CreateTestRunner(1000).ReCompileGodotProject(workingDirectory, MockGodotBinPath);
 
         // Assert
-        AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should return false on timeout").IsFalse();
+        AssertThat(result).OverrideFailureMessage("ReCompileGodotProject should return false on timeout").IsFalse();
 
         // Verify timeout error was logged
-        VerifyLoggerError("Godot compilation TIMEOUT");
+        AssertLogError(capture, "Godot compilation TIMEOUT");
         var errorCode = Environment.OSVersion.Platform == PlatformID.Win32NT ? -1 : 137;
-        VerifyLoggerError($"Rebuild Godot Project ends with exit code: {errorCode}");
+        AssertLogError(capture, $"Rebuild Godot Project ends with exit code: {errorCode}");
 
         // Verify the runner file was cleaned up after timeout
         var runnerPath = Path.Combine(workingDirectory, GodotRuntimeTestRunner.TEMP_TEST_RUNNER_DIR, "GdUnit4TestRunnerScene.cs");
@@ -191,6 +188,8 @@ public class GodotRuntimeTestRunnerTest
         var workingDirectory = Path.Combine(TestTempDirectory!, "working_dir_failure");
         Directory.CreateDirectory(workingDirectory);
 
+        using var capture = LogCapture.Watch<GodotRuntimeTestRunner>();
+
         // Act
         var result = CreateTestRunner(1000).InstallTestRunnerClasses(workingDirectory);
 
@@ -198,7 +197,7 @@ public class GodotRuntimeTestRunnerTest
         AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should return false on compilation failure").IsFalse();
 
         // Verify error message was logged
-        VerifyLoggerError("dotnet build failed with exit code: 1");
+        AssertLogError(capture, "dotnet build failed with exit code: 1");
 
         // Verify the runner file was cleaned up after failure
         var runnerPath = Path.Combine(workingDirectory, GodotRuntimeTestRunner.TEMP_TEST_RUNNER_DIR, "GdUnit4TestRunnerScene.cs");
@@ -216,6 +215,8 @@ public class GodotRuntimeTestRunnerTest
             // Copy Example Project into working directory
             CopyExampleProject(workingDirectory);
 
+            using var capture = LogCapture.Watch<GodotRuntimeTestRunner>();
+
             // Act
             var result = CreateTestRunner(30000).InstallTestRunnerClasses(workingDirectory);
 
@@ -223,8 +224,8 @@ public class GodotRuntimeTestRunnerTest
             AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should return true").IsTrue();
 
             // Verify log message
-            VerifyLoggerInfo("Installing GdUnit4TestRunnerScene at");
-            VerifyLoggerInfo("dotnet build completed successfully");
+            AssertLogInfo(capture, "Installing GdUnit4TestRunnerScene at");
+            AssertLogInfo(capture, "dotnet build completed successfully");
 
             // Verify the runner file was created in the correct location
             var runnerPath = Path.Combine(workingDirectory, GodotRuntimeTestRunner.TEMP_TEST_RUNNER_DIR, "GdUnit4TestRunnerScene.cs");
@@ -248,16 +249,18 @@ public class GodotRuntimeTestRunnerTest
             // Copy Example Project into working directory
             CopyExampleProject(workingDirectory);
 
+            using var capture = LogCapture.Watch<GodotRuntimeTestRunner>();
+
             // Act
             var result = CreateTestRunner(1000).InstallTestRunnerClasses(workingDirectory);
 
             // Assert
             AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should fail").IsFalse();
 
-            VerifyLoggerInfo("Installing GdUnit4TestRunnerScene at");
+            AssertLogInfo(capture, "Installing GdUnit4TestRunnerScene at");
             // Verify error messages
-            VerifyLoggerError("`dotnet build` did not complete within the configured timeout of 1000ms.");
-            VerifyLoggerError("dotnet build failed with exit code:");
+            AssertLogError(capture, "`dotnet build` did not complete within the configured timeout of 1000ms.");
+            AssertLogError(capture, "dotnet build failed with exit code:");
         }
         finally
         {
@@ -431,54 +434,28 @@ public class GodotRuntimeTestRunnerTest
                 UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
     }
 
-    /// <summary>
-    ///     Verify that logger.LogInfo was called with a message containing the specified text
-    /// </summary>
-    private void VerifyLoggerInfo(string expectedText)
+    private static void AssertLogInfo(LogCapture capture, string expectedText)
     {
-        try
-        {
-            LoggerMock.Verify(l => l.LogInfo(It.Is<string>(s => s.Contains(expectedText))), Times.AtLeastOnce());
-        }
-        catch (MockException)
-        {
-            // Capture all invocations to provide context
-            var invocations = LoggerMock.Invocations
-                .Where(i => i.Method.Name == "LogInfo")
-                .Select(i => i.Arguments[0]?.ToString() ?? "null")
-                .ToList();
-
-            var message = $"Expected log message containing '{expectedText}' was not found.\n\n" +
-                          $"Actual LogInfo calls ({invocations.Count}):\n" +
-                          string.Join("\n", invocations.Select((msg, i) => $"  {i + 1}. {msg}"));
-
-            AssertBool(true).OverrideFailureMessage(message).IsFalse();
-        }
+        var found = capture.Entries.Any(e => e.Level == LogLevel.Informational && e.Message.Contains(expectedText));
+        AssertBool(found)
+            .OverrideFailureMessage(BuildFailureMessage("LogInfo", expectedText, capture, LogLevel.Informational))
+            .IsTrue();
     }
 
-    /// <summary>
-    ///     Verify that logger.LogError was called with a message containing the specified text
-    /// </summary>
-    private void VerifyLoggerError(string expectedText)
+    private static void AssertLogError(LogCapture capture, string expectedText)
     {
-        try
-        {
-            LoggerMock.Verify(l => l.LogError(It.Is<string>(s => s.Contains(expectedText))), Times.AtLeastOnce());
-        }
-        catch (MockException)
-        {
-            // Capture all invocations to provide context
-            var invocations = LoggerMock.Invocations
-                .Where(i => i.Method.Name == "LogError")
-                .Select(i => i.Arguments[0]?.ToString() ?? "null")
-                .ToList();
+        var found = capture.Entries.Any(e => e.Level == LogLevel.Error && e.Message.Contains(expectedText));
+        AssertBool(found)
+            .OverrideFailureMessage(BuildFailureMessage("LogError", expectedText, capture, LogLevel.Error))
+            .IsTrue();
+    }
 
-            var message = $"Expected error message containing \n'{expectedText}'\n was not found.\n\n" +
-                          $"Actual Error entries ({invocations.Count}):\n" +
-                          string.Join("\n", invocations.Select((msg, i) => $"'{msg}'"));
-
-            AssertBool(true).OverrideFailureMessage(message).IsFalse();
-        }
+    private static string BuildFailureMessage(string level, string expectedText, LogCapture capture, LogLevel logLevel)
+    {
+        var entries = capture.EntriesOf(logLevel).Select(e => e.Message).ToList();
+        return $"Expected {level} containing '{expectedText}' was not found.\n\n" +
+               $"Actual entries ({entries.Count}):\n" +
+               string.Join("\n", entries.Select((msg, i) => $"  {i + 1}. {msg}"));
     }
 
     #endregion

--- a/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
+++ b/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
@@ -97,8 +97,8 @@ public class GodotRuntimeTestRunnerTest
         AssertThat(result).OverrideFailureMessage("ReCompileGodotProject should return true for successful compilation").IsTrue();
 
         // Verify logger was called with success messages
-        AssertLogInfo(capture, "Rebuild Godot Project ...");
-        AssertLogInfo(capture, "Rebuild Godot Project ends with exit code: 0");
+        VerifyLoggerInfo(capture, "Rebuild Godot Project ...");
+        VerifyLoggerInfo(capture, "Rebuild Godot Project ends with exit code: 0");
     }
 
     /// <summary>
@@ -123,8 +123,8 @@ public class GodotRuntimeTestRunnerTest
         AssertThat(result).OverrideFailureMessage("ReCompileGodotProject should return true for a process that completes just before timeout").IsTrue();
 
         // Verify success messages were logged
-        AssertLogInfo(capture, "Rebuild Godot Project ...");
-        AssertLogInfo(capture, "Rebuild Godot Project ends with exit code: 0");
+        VerifyLoggerInfo(capture, "Rebuild Godot Project ...");
+        VerifyLoggerInfo(capture, "Rebuild Godot Project ends with exit code: 0");
 
         // Verify that no timeout error was logged
         AssertThat(capture.EntriesOf(LogLevel.Error).Any(e => e.Message.Contains("Godot compilation TIMEOUT")))
@@ -153,9 +153,9 @@ public class GodotRuntimeTestRunnerTest
         AssertThat(result).OverrideFailureMessage("ReCompileGodotProject should return false on timeout").IsFalse();
 
         // Verify timeout error was logged
-        AssertLogError(capture, "Godot compilation TIMEOUT");
+        VerifyLoggerError(capture, "Godot compilation TIMEOUT");
         var errorCode = Environment.OSVersion.Platform == PlatformID.Win32NT ? -1 : 137;
-        AssertLogError(capture, $"Rebuild Godot Project ends with exit code: {errorCode}");
+        VerifyLoggerError(capture, $"Rebuild Godot Project ends with exit code: {errorCode}");
 
         // Verify the runner file was cleaned up after timeout
         var runnerPath = Path.Combine(workingDirectory, GodotRuntimeTestRunner.TEMP_TEST_RUNNER_DIR, "GdUnit4TestRunnerScene.cs");
@@ -197,7 +197,7 @@ public class GodotRuntimeTestRunnerTest
         AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should return false on compilation failure").IsFalse();
 
         // Verify error message was logged
-        AssertLogError(capture, "dotnet build failed with exit code: 1");
+        VerifyLoggerError(capture, "dotnet build failed with exit code: 1");
 
         // Verify the runner file was cleaned up after failure
         var runnerPath = Path.Combine(workingDirectory, GodotRuntimeTestRunner.TEMP_TEST_RUNNER_DIR, "GdUnit4TestRunnerScene.cs");
@@ -224,8 +224,8 @@ public class GodotRuntimeTestRunnerTest
             AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should return true").IsTrue();
 
             // Verify log message
-            AssertLogInfo(capture, "Installing GdUnit4TestRunnerScene at");
-            AssertLogInfo(capture, "dotnet build completed successfully");
+            VerifyLoggerInfo(capture, "Installing GdUnit4TestRunnerScene at");
+            VerifyLoggerInfo(capture, "dotnet build completed successfully");
 
             // Verify the runner file was created in the correct location
             var runnerPath = Path.Combine(workingDirectory, GodotRuntimeTestRunner.TEMP_TEST_RUNNER_DIR, "GdUnit4TestRunnerScene.cs");
@@ -257,10 +257,10 @@ public class GodotRuntimeTestRunnerTest
             // Assert
             AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should fail").IsFalse();
 
-            AssertLogInfo(capture, "Installing GdUnit4TestRunnerScene at");
+            VerifyLoggerInfo(capture, "Installing GdUnit4TestRunnerScene at");
             // Verify error messages
-            AssertLogError(capture, "`dotnet build` did not complete within the configured timeout of 1000ms.");
-            AssertLogError(capture, "dotnet build failed with exit code:");
+            VerifyLoggerError(capture, "`dotnet build` did not complete within the configured timeout of 1000ms.");
+            VerifyLoggerError(capture, "dotnet build failed with exit code:");
         }
         finally
         {
@@ -434,28 +434,22 @@ public class GodotRuntimeTestRunnerTest
                 UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
     }
 
-    private static void AssertLogInfo(LogCapture capture, string expectedText)
-    {
-        var found = capture.Entries.Any(e => e.Level == LogLevel.Informational && e.Message.Contains(expectedText));
-        AssertBool(found)
-            .OverrideFailureMessage(BuildFailureMessage("LogInfo", expectedText, capture, LogLevel.Informational))
+    private static void VerifyLoggerInfo(LogCapture capture, string expectedText)
+        => AssertThat(capture.EntriesOf(LogLevel.Informational).Any(e => e.Message.Contains(expectedText, StringComparison.Ordinal)))
+            .OverrideFailureMessage(FormatFailure(capture, LogLevel.Informational, expectedText))
             .IsTrue();
-    }
 
-    private static void AssertLogError(LogCapture capture, string expectedText)
-    {
-        var found = capture.Entries.Any(e => e.Level == LogLevel.Error && e.Message.Contains(expectedText));
-        AssertBool(found)
-            .OverrideFailureMessage(BuildFailureMessage("LogError", expectedText, capture, LogLevel.Error))
+    private static void VerifyLoggerError(LogCapture capture, string expectedText)
+        => AssertThat(capture.EntriesOf(LogLevel.Error).Any(e => e.Message.Contains(expectedText, StringComparison.Ordinal)))
+            .OverrideFailureMessage(FormatFailure(capture, LogLevel.Error, expectedText))
             .IsTrue();
-    }
 
-    private static string BuildFailureMessage(string level, string expectedText, LogCapture capture, LogLevel logLevel)
+    private static string FormatFailure(LogCapture capture, LogLevel level, string expectedText)
     {
-        var entries = capture.EntriesOf(logLevel).Select(e => e.Message).ToList();
-        return $"Expected {level} containing '{expectedText}' was not found.\n\n" +
-               $"Actual entries ({entries.Count}):\n" +
-               string.Join("\n", entries.Select((msg, i) => $"  {i + 1}. {msg}"));
+        var entries = capture.EntriesOf(level);
+        return $"Expected {level} message containing '{expectedText}' was not found.\n" +
+               $"Actual {level} messages ({entries.Count}):\n" +
+               string.Join("\n", entries.Select((e, i) => $"  {i + 1}. {e.Message}"));
     }
 
     #endregion

--- a/Api/src/api/ITestEngineLogger.cs
+++ b/Api/src/api/ITestEngineLogger.cs
@@ -17,21 +17,36 @@ public interface ITestEngineLogger
     /// </summary>
     /// <param name="message">The informational message to log.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void LogInfo(string message) => SendMessage(LogLevel.Informational, message);
+    sealed void LogInfo(string message) => SendMessage(LogLevel.Informational, message);
 
     /// <summary>
     ///     Logs a warning message.
     /// </summary>
     /// <param name="message">The warning message to log.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void LogWarning(string message) => SendMessage(LogLevel.Warning, message);
+    sealed void LogWarning(string message) => SendMessage(LogLevel.Warning, message);
 
     /// <summary>
     ///     Logs an error message.
     /// </summary>
     /// <param name="message">The error message to log.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void LogError(string message) => SendMessage(LogLevel.Error, message);
+    sealed void LogError(string message) => SendMessage(LogLevel.Error, message);
+
+    /// <summary>
+    ///     Logs a debug message. The method body is only compiled in DEBUG builds;
+    ///     in Release builds it is a no-op with no runtime overhead.
+    /// </summary>
+    /// <param name="message">The debug message to log.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    sealed void LogDebug(string message)
+    {
+#if DEBUG
+#pragma warning disable IDE0022 // #if DEBUG cannot be used inside an expression body
+        SendMessage(LogLevel.Debug, message);
+#pragma warning restore IDE0022
+#endif
+    }
 
     /// <summary>
     ///     Sends a message to the enabled loggers.

--- a/Api/src/api/LogCapture.cs
+++ b/Api/src/api/LogCapture.cs
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Api;
+
+using System.Collections.Concurrent;
+
+using Core.Logging;
+
+/// <summary>
+///     A thread-safe test utility that captures log messages emitted by specific classes,
+///     allowing tests to assert on log output without noise from unrelated components.
+/// </summary>
+/// <remarks>
+///     Watch one or more classes, then assert on the collected messages:
+///     <code>
+///     using var capture = LogCapture.Watch&lt;ClassA&gt;();
+///
+///     // exercise code under test
+///
+///     AssertThat(capture.Count(LogLevel.Informational)).IsEqual(1);
+///     </code>
+///     Multiple classes can be watched in a single scope:
+///     <code>
+///     using var capture = LogCapture.Watch&lt;ClassA, ClassB&gt;();
+///     </code>
+///     <see cref="Dispose" /> automatically stops watching so parallel tests do not interfere.
+/// </remarks>
+/// <remarks>
+///     <b>Limitation:</b> only classes that obtain their logger via
+///     <see cref="LoggerFactory.GetLogger{T}" /> are captured. Classes that receive an
+///     <see cref="ITestEngineLogger" /> through constructor injection bypass this mechanism.
+///     Migrate those classes to <c>LoggerFactory.GetLogger&lt;T&gt;()</c> to make them watchable.
+/// </remarks>
+public sealed class LogCapture : IDisposable
+{
+    // Type → set of active captures (thread-safe, O(1) removal via TryRemove)
+    private static readonly ConcurrentDictionary<Type, ConcurrentDictionary<LogCapture, byte>> Registry = new();
+
+    private readonly ConcurrentQueue<LogEntry> captured = new();
+    private readonly Type[] registeredTypes;
+
+    private LogCapture(Type[] types)
+    {
+        registeredTypes = types;
+        foreach (var type in types)
+            _ = Registry.GetOrAdd(type, _ => new ConcurrentDictionary<LogCapture, byte>()).TryAdd(this, 0);
+    }
+
+    /// <summary>Gets all log entries captured so far, in the order they were received.</summary>
+    public IReadOnlyList<LogEntry> Entries => [.. captured];
+
+    /// <summary>
+    ///     Watches log messages emitted by <typeparamref name="T" />.
+    /// </summary>
+    /// <typeparam name="T">The class whose log output should be captured.</typeparam>
+    /// <returns>A <see cref="LogCapture" /> scope that must be disposed at the end of the test.</returns>
+    public static LogCapture Watch<T>() => Watch(typeof(T));
+
+    /// <summary>
+    ///     Watches log messages emitted by <typeparamref name="T1" /> and <typeparamref name="T2" />.
+    /// </summary>
+    /// <typeparam name="T1">The first class whose log output should be captured.</typeparam>
+    /// <typeparam name="T2">The second class whose log output should be captured.</typeparam>
+    /// <returns>A <see cref="LogCapture" /> scope that must be disposed at the end of the test.</returns>
+    public static LogCapture Watch<T1, T2>() => Watch(typeof(T1), typeof(T2));
+
+    /// <summary>
+    ///     Watches log messages emitted by <typeparamref name="T1" />, <typeparamref name="T2" />, and
+    ///     <typeparamref name="T3" />.
+    /// </summary>
+    /// <typeparam name="T1">The first class whose log output should be captured.</typeparam>
+    /// <typeparam name="T2">The second class whose log output should be captured.</typeparam>
+    /// <typeparam name="T3">The third class whose log output should be captured.</typeparam>
+    /// <returns>A <see cref="LogCapture" /> scope that must be disposed at the end of the test.</returns>
+    public static LogCapture Watch<T1, T2, T3>() => Watch(typeof(T1), typeof(T2), typeof(T3));
+
+    /// <summary>
+    ///     Watches log messages emitted by all specified <paramref name="types" />.
+    /// </summary>
+    /// <param name="types">The classes whose log output should be captured.</param>
+    /// <returns>A <see cref="LogCapture" /> scope that must be disposed at the end of the test.</returns>
+    public static LogCapture Watch(params Type[] types) => new(types ?? throw new ArgumentNullException(nameof(types)));
+
+    /// <summary>Stops watching and removes this capture from the registry so no further messages are routed to it.</summary>
+    public void Dispose()
+    {
+        foreach (var type in registeredTypes)
+        {
+            if (Registry.TryGetValue(type, out var captures))
+                _ = captures.TryRemove(this, out _);
+        }
+    }
+
+    /// <summary>Discards all entries collected so far, resetting the capture to an empty state.</summary>
+    public void Clear() => captured.Clear();
+
+    /// <summary>
+    ///     Returns the number of captured messages at the given <paramref name="logLevel" />.
+    /// </summary>
+    /// <param name="logLevel">The severity level to count.</param>
+    /// <returns>The number of captured messages matching <paramref name="logLevel" />.</returns>
+    public int Count(LogLevel logLevel) => captured.Count(e => e.Level == logLevel);
+
+    /// <summary>
+    ///     Returns all captured entries at the given <paramref name="logLevel" />, in the order they were received.
+    /// </summary>
+    /// <param name="logLevel">The severity level to filter by.</param>
+    /// <returns>All captured <see cref="LogEntry" /> instances matching <paramref name="logLevel" />.</returns>
+    public IReadOnlyList<LogEntry> EntriesOf(LogLevel logLevel)
+        => [.. captured.Where(e => e.Level == logLevel)];
+
+    /// <summary>Returns all active captures watching <paramref name="type" />.</summary>
+    /// <param name="type">The type to look up.</param>
+    /// <returns>All active <see cref="LogCapture" /> instances watching <paramref name="type" />.</returns>
+    internal static IEnumerable<LogCapture> GetCaptures(Type type)
+        => Registry.TryGetValue(type, out var captures) ? captures.Keys : [];
+
+    /// <summary>Records a single log entry. Called by <see cref="TypedLogger" />.</summary>
+    /// <param name="level">The severity level.</param>
+    /// <param name="message">The message text.</param>
+    /// <param name="source">The class that emitted the message.</param>
+    internal void Capture(LogLevel level, string message, Type source)
+        => captured.Enqueue(new LogEntry(level, message, source));
+}

--- a/Api/src/api/LogCapture.cs
+++ b/Api/src/api/LogCapture.cs
@@ -113,7 +113,7 @@ public sealed class LogCapture : IDisposable
     /// <summary>Returns all active captures watching <paramref name="type" />.</summary>
     /// <param name="type">The type to look up.</param>
     /// <returns>All active <see cref="LogCapture" /> instances watching <paramref name="type" />.</returns>
-    internal static IEnumerable<LogCapture> GetCaptures(Type type)
+    internal static ICollection<LogCapture> GetCaptures(Type type)
         => Registry.TryGetValue(type, out var captures) ? captures.Keys : [];
 
     /// <summary>Records a single log entry. Called by <see cref="TypedLogger" />.</summary>

--- a/Api/src/api/LogEntry.cs
+++ b/Api/src/api/LogEntry.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Api;
+
+/// <summary>A single log entry captured by <see cref="LogCapture" />.</summary>
+/// <param name="Level">The severity level of the message.</param>
+/// <param name="Message">The message text.</param>
+/// <param name="Source">The class that emitted the message.</param>
+public sealed record LogEntry(LogLevel Level, string Message, Type Source);

--- a/Api/src/api/LogLevel.cs
+++ b/Api/src/api/LogLevel.cs
@@ -20,5 +20,10 @@ public enum LogLevel
     /// <summary>
     ///     Error message.
     /// </summary>
-    Error = 2
+    Error = 2,
+
+    /// <summary>
+    ///     Debug message. Only emitted in DEBUG builds via <see cref="ITestEngineLogger.LogDebug" />.
+    /// </summary>
+    Debug = 3
 }

--- a/Api/src/api/LoggerFactory.cs
+++ b/Api/src/api/LoggerFactory.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Api;
+
+using Core.Logging;
+
+/// <summary>
+///     Factory for obtaining class-scoped loggers that integrate with <see cref="LogCapture" />.
+/// </summary>
+/// <remarks>
+///     Obtain a scoped logger in any class:
+///     <code>
+///     private static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger&lt;MyClass&gt;();
+///     </code>
+///     Log messages are forwarded to any active <see cref="LogCapture" /> scopes watching that class,
+///     and to the global engine logger.
+/// </remarks>
+public static class LoggerFactory
+{
+    /// <summary>
+    ///     Returns a class-scoped logger for <typeparamref name="T" />.
+    ///     Log messages are forwarded to any active <see cref="LogCapture" /> scopes registered for
+    ///     <typeparamref name="T" /> and to the global logger.
+    /// </summary>
+    /// <typeparam name="T">The class the logger is associated with.</typeparam>
+    /// <returns>A class-scoped <see cref="ITestEngineLogger" /> for <typeparamref name="T" />.</returns>
+    public static ITestEngineLogger GetLogger<T>() => new TypedLogger(typeof(T));
+
+    /// <summary>
+    ///     Returns a class-scoped logger for <paramref name="type" />.
+    /// </summary>
+    /// <param name="type">The class the logger is associated with.</param>
+    /// <returns>A class-scoped <see cref="ITestEngineLogger" /> for <paramref name="type" />.</returns>
+    public static ITestEngineLogger GetLogger(Type type) => new TypedLogger(type);
+}

--- a/Api/src/api/LoggerFactory.cs
+++ b/Api/src/api/LoggerFactory.cs
@@ -25,12 +25,12 @@ public static class LoggerFactory
     /// </summary>
     /// <typeparam name="T">The class the logger is associated with.</typeparam>
     /// <returns>A class-scoped <see cref="ITestEngineLogger" /> for <typeparamref name="T" />.</returns>
-    public static ITestEngineLogger GetLogger<T>() => new TypedLogger(typeof(T));
+    public static ITestEngineLogger GetLogger<T>() => new TypedLogger(typeof(T), TestEngineLogger.Global);
 
     /// <summary>
     ///     Returns a class-scoped logger for <paramref name="type" />.
     /// </summary>
     /// <param name="type">The class the logger is associated with.</param>
     /// <returns>A class-scoped <see cref="ITestEngineLogger" /> for <paramref name="type" />.</returns>
-    public static ITestEngineLogger GetLogger(Type type) => new TypedLogger(type);
+    public static ITestEngineLogger GetLogger(Type type) => new TypedLogger(type, TestEngineLogger.Global);
 }

--- a/Api/src/core/GdUnit4TestEngine.cs
+++ b/Api/src/core/GdUnit4TestEngine.cs
@@ -191,7 +191,7 @@ internal sealed class GdUnit4TestEngine : ITestEngine
         // Run tests that require Godot runtime
         if (godotExecutorTestSuites.Count > 0)
         {
-            var godotRunner = new GodotRuntimeTestRunner(Logger, debuggerFramework, Settings);
+            var godotRunner = new GodotRuntimeTestRunner(debuggerFramework, Settings);
             ActiveTestRunners.Add(godotRunner);
             godotRunner.RunAndWait(godotExecutorTestSuites, eventListener, cancellationToken);
             _ = ActiveTestRunners.Remove(godotRunner);

--- a/Api/src/core/GdUnit4TestEngine.cs
+++ b/Api/src/core/GdUnit4TestEngine.cs
@@ -11,6 +11,8 @@ using Discovery;
 
 using Extensions;
 
+using Logging;
+
 using Runners;
 
 internal sealed class GdUnit4TestEngine : ITestEngine
@@ -22,6 +24,7 @@ internal sealed class GdUnit4TestEngine : ITestEngine
     {
         Settings = settings;
         Logger = logger;
+        TestEngineLogger.Register(logger);
     }
 
     private TestEngineSettings Settings { get; }

--- a/Api/src/core/execution/GodotRuntimeExecutor.cs
+++ b/Api/src/core/execution/GodotRuntimeExecutor.cs
@@ -29,8 +29,10 @@ using static Api.ReportType;
 /// </remarks>
 internal sealed class GodotRuntimeExecutor : InOutPipeProxy<NamedPipeClientStream>, ICommandExecutor
 {
-    public GodotRuntimeExecutor(ITestEngineLogger logger)
-        : base(new NamedPipeClientStream(".", PIPE_NAME, PipeDirection.InOut, PipeOptions.Asynchronous, TokenImpersonationLevel.Impersonation), logger)
+    private static new readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<GodotRuntimeExecutor>();
+
+    public GodotRuntimeExecutor()
+        : base(new NamedPipeClientStream(".", PIPE_NAME, PipeDirection.InOut, PipeOptions.Asynchronous, TokenImpersonationLevel.Impersonation), Logger)
     {
     }
 

--- a/Api/src/core/logging/NoOpTestEngineLogger.cs
+++ b/Api/src/core/logging/NoOpTestEngineLogger.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Core.Logging;
+
+using Api;
+
+/// <summary>Discards all log messages. Used as the default logger before one is registered.</summary>
+internal sealed class NoOpTestEngineLogger : ITestEngineLogger
+{
+    internal static readonly NoOpTestEngineLogger Instance = new();
+
+    private NoOpTestEngineLogger()
+    {
+    }
+
+    void ITestEngineLogger.SendMessage(LogLevel logLevel, string message)
+    {
+    }
+}

--- a/Api/src/core/logging/TestEngineLogger.cs
+++ b/Api/src/core/logging/TestEngineLogger.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Core.Logging;
+
+using Api;
+
+/// <summary>
+///     Manages the global logger instance used by all class-scoped loggers.
+///     Intended for engine-internal use only; use <see cref="LoggerFactory" /> to obtain loggers.
+/// </summary>
+/// <remarks>
+///     Register the real logger once at engine startup:
+///     <code>
+///     TestEngineLogger.Register(myLogger);
+///     </code>
+/// </remarks>
+internal static class TestEngineLogger
+{
+    private static volatile ITestEngineLogger global = NoOpTestEngineLogger.Instance;
+
+    /// <summary>Gets the currently registered global logger.</summary>
+    internal static ITestEngineLogger Global => global;
+
+    /// <summary>
+    ///     Registers the global logger used as the fallback for all class-scoped loggers.
+    ///     Intended to be called once at engine startup.
+    /// </summary>
+    /// <param name="logger">The logger implementation to register.</param>
+    internal static void Register(ITestEngineLogger logger)
+        => global = logger ?? throw new ArgumentNullException(nameof(logger));
+}

--- a/Api/src/core/logging/TypedLogger.cs
+++ b/Api/src/core/logging/TypedLogger.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 Mike Schulze
+// MIT License - See LICENSE file in the repository root for full license text
+
+namespace GdUnit4.Core.Logging;
+
+using System;
+
+using Api;
+
+/// <summary>
+///     An <see cref="ITestEngineLogger" /> that routes messages to active <see cref="LogCapture" /> scopes
+///     registered for its type, and forwards all messages to the global logger.
+/// </summary>
+internal sealed class TypedLogger(Type type) : ITestEngineLogger
+{
+    void ITestEngineLogger.SendMessage(LogLevel logLevel, string message)
+    {
+        foreach (var capture in LogCapture.GetCaptures(type))
+            capture.Capture(logLevel, message, type);
+
+        switch (logLevel)
+        {
+            case LogLevel.Debug:
+                TestEngineLogger.Global.LogDebug(message);
+                break;
+            case LogLevel.Informational:
+                TestEngineLogger.Global.LogInfo(message);
+                break;
+            case LogLevel.Warning:
+                TestEngineLogger.Global.LogWarning(message);
+                break;
+            case LogLevel.Error:
+                TestEngineLogger.Global.LogError(message);
+                break;
+            default:
+                TestEngineLogger.Global.LogInfo(message);
+                break;
+        }
+    }
+}

--- a/Api/src/core/logging/TypedLogger.cs
+++ b/Api/src/core/logging/TypedLogger.cs
@@ -3,37 +3,48 @@
 
 namespace GdUnit4.Core.Logging;
 
-using System;
-
 using Api;
 
 /// <summary>
 ///     An <see cref="ITestEngineLogger" /> that routes messages to active <see cref="LogCapture" /> scopes
-///     registered for its type, and forwards all messages to the global logger.
+///     registered for its type, and forwards all messages to the backing backingLogger.
 /// </summary>
-internal sealed class TypedLogger(Type type) : ITestEngineLogger
+/// <param name="type">The class this logger is scoped to.</param>
+/// <param name="backingLogger">The backing logger to forward messages to after dispatching to any active captures.</param>
+internal sealed class TypedLogger(Type type, ITestEngineLogger backingLogger) : ITestEngineLogger
 {
     void ITestEngineLogger.SendMessage(LogLevel logLevel, string message)
     {
-        foreach (var capture in LogCapture.GetCaptures(type))
+        var captureSet = LogCapture.GetCaptures(type);
+        foreach (var capture in captureSet)
             capture.Capture(logLevel, message, type);
+
+        // When a LogCapture is active the message is intentionally being tested.
+        // Demote Error/Warning to Informational so the message stays visible in test output
+        // but does not leak into VSTest's error channel and falsely fail the run.
+        // Prefix the forwarded message so the original severity remains visible in raw output.
+        if (captureSet.Count > 0 && logLevel is LogLevel.Error or LogLevel.Warning)
+        {
+            backingLogger.LogInfo($"[Captured {logLevel}] {message}");
+            return;
+        }
 
         switch (logLevel)
         {
             case LogLevel.Debug:
-                TestEngineLogger.Global.LogDebug(message);
+                backingLogger.LogDebug(message);
                 break;
             case LogLevel.Informational:
-                TestEngineLogger.Global.LogInfo(message);
+                backingLogger.LogInfo(message);
                 break;
             case LogLevel.Warning:
-                TestEngineLogger.Global.LogWarning(message);
+                backingLogger.LogWarning(message);
                 break;
             case LogLevel.Error:
-                TestEngineLogger.Global.LogError(message);
+                backingLogger.LogError(message);
                 break;
             default:
-                TestEngineLogger.Global.LogInfo(message);
+                backingLogger.LogInfo(message);
                 break;
         }
     }

--- a/Api/src/core/runners/GodotLogger.cs
+++ b/Api/src/core/runners/GodotLogger.cs
@@ -14,6 +14,9 @@ internal sealed class GodotLogger : ITestEngineLogger
     {
         switch (logLevel)
         {
+            case LogLevel.Debug:
+                GD.PrintS("[DEBUG]:", message);
+                break;
             case LogLevel.Informational:
                 GD.PrintS(message);
                 break;

--- a/Api/src/core/runners/GodotRuntimeTestRunner.cs
+++ b/Api/src/core/runners/GodotRuntimeTestRunner.cs
@@ -40,7 +40,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
     /// <param name="debuggerFramework">Framework for debugging support.</param>
     /// <param name="settings">Test engine configuration settings.</param>
     internal GodotRuntimeTestRunner(IDebuggerFramework debuggerFramework, TestEngineSettings settings)
-        : base(new GodotRuntimeExecutor(Logger), Logger, settings)
+        : base(new GodotRuntimeExecutor(), Logger, settings)
     {
         this.settings = settings;
         DebuggerFramework = debuggerFramework;
@@ -372,6 +372,8 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
                 compileProcess.Kill(true);
             }
 
+            // Ensure all async events (including Exited) are fully processed before reading ExitCode
+            compileProcess.WaitForExit();
             return compileProcess.ExitCode == 0;
         }
 #pragma warning disable CA1031

--- a/Api/src/core/runners/GodotRuntimeTestRunner.cs
+++ b/Api/src/core/runners/GodotRuntimeTestRunner.cs
@@ -29,18 +29,18 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
     /// </summary>
     internal const string TEMP_TEST_RUNNER_DIR = "gdunit4_testadapter_v5";
 
+    private static new readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<GodotRuntimeTestRunner>();
+
     private readonly TestEngineSettings settings;
     private Process? process;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="GodotRuntimeTestRunner" /> class.
-    ///     Initializes a new instance of the GodotRuntimeTestRunner.
     /// </summary>
-    /// <param name="logger">The test engine logger for diagnostic output.</param>
     /// <param name="debuggerFramework">Framework for debugging support.</param>
     /// <param name="settings">Test engine configuration settings.</param>
-    internal GodotRuntimeTestRunner(ITestEngineLogger logger, IDebuggerFramework debuggerFramework, TestEngineSettings settings)
-        : base(new GodotRuntimeExecutor(logger), logger, settings)
+    internal GodotRuntimeTestRunner(IDebuggerFramework debuggerFramework, TestEngineSettings settings)
+        : base(new GodotRuntimeExecutor(Logger), Logger, settings)
     {
         this.settings = settings;
         DebuggerFramework = debuggerFramework;

--- a/TestAdapter/src/utilities/Logger.cs
+++ b/TestAdapter/src/utilities/Logger.cs
@@ -33,11 +33,15 @@ public class Logger : ITestEngineLogger
 
     /// <summary>
     ///     Sends a message to the VS test platform logger with the appropriate level.
+    ///     Debug-level messages are suppressed as the VS test platform has no equivalent level.
     /// </summary>
     /// <param name="logLevel">The severity level of the message.</param>
     /// <param name="message">The message to log.</param>
     public void SendMessage(LogLevel logLevel, string message)
     {
+        if (logLevel == LogLevel.Debug)
+            return;
+
         if (LevelMap.TryGetValue(logLevel, out var testLogLevel))
             delegator.SendMessage(testLogLevel, $"[GdUnit4] {message}");
         else


### PR DESCRIPTION
There was no centralized way to obtain a logger without propagating ITestEngineLogger through constructor injection across every component. Tests also had no built-in mechanism to capture log output and assert on it — each project had to maintain its own no-op or spy logger.

* LoggerFactory (public, GdUnit4.Api)

A static factory that lets any class obtain a class-scoped logger without
being part of the injection chain:

```cs
private static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger();
```

* LogCapture (public, GdUnit4.Api)

A test utility that intercepts log messages emitted by specific classes so
tests can assert on them without noise from unrelated components:

```cs
using var capture = LogCapture.Watch();

new OrderService().PlaceOrder(42);

AssertThat(capture.Entries).ContainsExactly(
    new LogEntry(LogLevel.Informational, "Order 42 placed", typeof(OrderService)),
    new LogEntry(LogLevel.Warning,       "Stock running low", typeof(OrderService)));
```

(cherry picked from commit 99816ebf980f3bed5db6b5659f413c358a955d11)