### PR TITLE
GD-436: Fix named pipe collision when running multiple assemblies in parallel

### DIFF
--- a/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
+++ b/Api.Test/src/core/runners/GodotRuntimeTestRunnerTest.cs
@@ -7,7 +7,6 @@ using System.Linq;
 
 using Api;
 
-using GdUnit4.Core.Logging;
 using GdUnit4.Core.Runners;
 
 using Moq;
@@ -49,6 +48,7 @@ public class GodotRuntimeTestRunnerTest
     }
 
     private GodotRuntimeTestRunner CreateTestRunner(int compileTimeout) => new(
+        "assemblyId",
         DebuggerFrameworkMock.Object,
         new TestEngineSettings { CompileProcessTimeout = compileTimeout });
 
@@ -98,8 +98,8 @@ public class GodotRuntimeTestRunnerTest
         AssertThat(result).OverrideFailureMessage("ReCompileGodotProject should return true for successful compilation").IsTrue();
 
         // Verify logger was called with success messages
-        VerifyLoggerInfo(capture, "Rebuild Godot Project ...");
-        VerifyLoggerInfo(capture, "Rebuild Godot Project ends with exit code: 0");
+        VerifyLoggerInfo(capture, "Rebuilding Godot Project ...");
+        VerifyLoggerInfo(capture, "Rebuilding Godot Project ends with exit code: 0");
     }
 
     /// <summary>
@@ -124,8 +124,8 @@ public class GodotRuntimeTestRunnerTest
         AssertThat(result).OverrideFailureMessage("ReCompileGodotProject should return true for a process that completes just before timeout").IsTrue();
 
         // Verify success messages were logged
-        VerifyLoggerInfo(capture, "Rebuild Godot Project ...");
-        VerifyLoggerInfo(capture, "Rebuild Godot Project ends with exit code: 0");
+        VerifyLoggerInfo(capture, "Rebuilding Godot Project ...");
+        VerifyLoggerInfo(capture, "Rebuilding Godot Project ends with exit code: 0");
 
         // Verify that no timeout error was logged
         AssertThat(capture.EntriesOf(LogLevel.Error).Any(e => e.Message.Contains("Godot compilation TIMEOUT")))
@@ -156,7 +156,7 @@ public class GodotRuntimeTestRunnerTest
         // Verify timeout error was logged
         VerifyLoggerError(capture, "Godot compilation TIMEOUT");
         var errorCode = Environment.OSVersion.Platform == PlatformID.Win32NT ? -1 : 137;
-        VerifyLoggerError(capture, $"Rebuild Godot Project ends with exit code: {errorCode}");
+        VerifyLoggerError(capture, $"Rebuilding Godot Project ends with exit code: {errorCode}");
 
         // Verify the runner file was cleaned up after timeout
         var runnerPath = Path.Combine(workingDirectory, GodotRuntimeTestRunner.TEMP_TEST_RUNNER_DIR, "GdUnit4TestRunnerScene.cs");
@@ -198,7 +198,8 @@ public class GodotRuntimeTestRunnerTest
         AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should return false on compilation failure").IsFalse();
 
         // Verify error message was logged
-        VerifyLoggerError(capture, "dotnet build failed with exit code: 1");
+        var dotnetExitCode = Environment.OSVersion.Platform == PlatformID.Win32NT ? 1 : 137;
+        VerifyLoggerError(capture, $"dotnet build failed with exit code: {dotnetExitCode}");
 
         // Verify the runner file was cleaned up after failure
         var runnerPath = Path.Combine(workingDirectory, GodotRuntimeTestRunner.TEMP_TEST_RUNNER_DIR, "GdUnit4TestRunnerScene.cs");
@@ -225,7 +226,7 @@ public class GodotRuntimeTestRunnerTest
             AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should return true").IsTrue();
 
             // Verify log message
-            VerifyLoggerInfo(capture, "Installing GdUnit4TestRunnerScene at");
+            VerifyLoggerInfo(capture, "Installing GdUnit4TestRunner at");
             VerifyLoggerInfo(capture, "dotnet build completed successfully");
 
             // Verify the runner file was created in the correct location
@@ -258,10 +259,11 @@ public class GodotRuntimeTestRunnerTest
             // Assert
             AssertThat(result).OverrideFailureMessage("InstallTestRunnerClasses should fail").IsFalse();
 
-            VerifyLoggerInfo(capture, "Installing GdUnit4TestRunnerScene at");
+            VerifyLoggerInfo(capture, "Installing GdUnit4TestRunner at");
             // Verify error messages
             VerifyLoggerError(capture, "`dotnet build` did not complete within the configured timeout of 1000ms.");
-            VerifyLoggerError(capture, "dotnet build failed with exit code:");
+            var dotnetExitCode = Environment.OSVersion.Platform == PlatformID.Win32NT ? -1 : 137;
+            VerifyLoggerError(capture, $"dotnet build failed with exit code: {dotnetExitCode}");
         }
         finally
         {
@@ -285,7 +287,7 @@ public class GodotRuntimeTestRunnerTest
                 continue;
 
             var destFile = Path.Combine(destDir, relativePath);
-            Directory.CreateDirectory(Path.GetDirectoryName(destFile));
+            Directory.CreateDirectory(Path.GetDirectoryName(destFile)!);
             File.Copy(file, destFile, true);
         }
     }
@@ -436,19 +438,19 @@ public class GodotRuntimeTestRunnerTest
     }
 
     private static void VerifyLoggerInfo(LogCapture capture, string expectedText)
-        => AssertThat(capture.EntriesOf(LogLevel.Informational).Any(e => e.Message.Contains(expectedText, StringComparison.Ordinal)))
+        => AssertThat(capture.EntriesOf(LogLevel.Informational).Any(e => e.Message.Equals(expectedText, StringComparison.Ordinal)))
             .OverrideFailureMessage(FormatFailure(capture, LogLevel.Informational, expectedText))
             .IsTrue();
 
     private static void VerifyLoggerError(LogCapture capture, string expectedText)
-        => AssertThat(capture.EntriesOf(LogLevel.Error).Any(e => e.Message.Contains(expectedText, StringComparison.Ordinal)))
+        => AssertThat(capture.EntriesOf(LogLevel.Error).Any(e => e.Message.Equals(expectedText, StringComparison.Ordinal)))
             .OverrideFailureMessage(FormatFailure(capture, LogLevel.Error, expectedText))
             .IsTrue();
 
     private static string FormatFailure(LogCapture capture, LogLevel level, string expectedText)
     {
         var entries = capture.EntriesOf(level);
-        return $"Expected {level} message containing '{expectedText}' was not found.\n" +
+        return $"Expected {level} message equal to '{expectedText}' was not found.\n" +
                $"Actual {level} messages ({entries.Count}):\n" +
                string.Join("\n", entries.Select((e, i) => $"  {i + 1}. {e.Message}"));
     }

--- a/Api/ReleaseNotes.txt
+++ b/Api/ReleaseNotes.txt
@@ -14,6 +14,8 @@ v5.1.0
 * GD-340: Fixing GdUnit4NetApiGodotBridge test discovery on linux paths
 * GD-348: Fixing task handling using AwaitMethod with WithTimeout
 * GD-366: Fixing `NO Godot C# SUPPORT NOT DETECTED` by increasing the used timeout to capture the supported arguments
+* GD-436: Fixing named pipe collision when running multiple assemblies in parallel
+* GD-437: Fixing respect CompileProcessTimeout in dotnet build step
 
 ✨ Improvements
 * GD-311: Verify the Godot binary has C# support before running godot runtime tests to avoid invalid test execution.
@@ -28,6 +30,7 @@ v5.1.0
     AssertString("foo").IsEqual("bar").OverrideFailureMessage("Custom failure message"); // ❌ Compile error
     ```
 * GD-332: Do not allow returning null values on AutoFree to avoid spamming warnings
+* GD-426: Add ambient LoggerFactory and LogCapture for testing
 
 v5.0.0
 

--- a/Api/src/core/GdUnit4TestEngine.cs
+++ b/Api/src/core/GdUnit4TestEngine.cs
@@ -174,7 +174,7 @@ internal sealed class GdUnit4TestEngine(TestEngineSettings settings, ITestEngine
                     Directory.SetCurrentDirectory(projectWorkingDir);
                     Logger.LogInfo($"Set current working directory to: {projectWorkingDir}");
 
-                    ExecuteEngineTests(testAssemblyNode.Suites, eventListener, debuggerFramework, cancellationToken);
+                    ExecuteEngineTests(assemblyId, testAssemblyNode.Suites, eventListener, debuggerFramework, cancellationToken);
 
                     Logger.LogInfo($"Completed tests for assembly: {testAssemblyNode.AssemblyPath}");
                 }
@@ -182,6 +182,7 @@ internal sealed class GdUnit4TestEngine(TestEngineSettings settings, ITestEngine
             cancellationToken);
 
     private void ExecuteEngineTests(
+        string assemblyId,
         List<TestSuiteNode> testSuiteNodes,
         ITestEventListener eventListener,
         IDebuggerFramework debuggerFramework,
@@ -192,7 +193,7 @@ internal sealed class GdUnit4TestEngine(TestEngineSettings settings, ITestEngine
         // Run tests that require Godot runtime
         if (godotExecutorTestSuites.Count > 0)
         {
-            var godotRunner = new GodotRuntimeTestRunner(debuggerFramework, Settings);
+            var godotRunner = new GodotRuntimeTestRunner(assemblyId, debuggerFramework, Settings);
             ActiveTestRunners.Add(godotRunner);
             godotRunner.RunAndWait(godotExecutorTestSuites, eventListener, cancellationToken);
             _ = ActiveTestRunners.Remove(godotRunner);

--- a/Api/src/core/discovery/TestCaseDiscoverer.cs
+++ b/Api/src/core/discovery/TestCaseDiscoverer.cs
@@ -10,10 +10,10 @@ using Api;
 
 using Godot;
 
+using Logging;
+
 using Mono.Cecil;
 using Mono.Cecil.Cil;
-
-using Runners;
 
 /// <summary>
 ///     Discovers test cases in assemblies by scanning for test attributes and analyzing debug information.

--- a/Api/src/core/execution/GdUnit4RuntimeExecutorGodotBridge.cs
+++ b/Api/src/core/execution/GdUnit4RuntimeExecutorGodotBridge.cs
@@ -14,9 +14,9 @@ using Extensions;
 using Godot;
 using Godot.Collections;
 
-using Newtonsoft.Json;
+using Logging;
 
-using Runners;
+using Newtonsoft.Json;
 
 internal class GdUnit4RuntimeExecutorGodotBridge
 {

--- a/Api/src/core/execution/GodotRuntimeExecutor.cs
+++ b/Api/src/core/execution/GodotRuntimeExecutor.cs
@@ -33,8 +33,8 @@ internal sealed class GodotRuntimeExecutor : InOutPipeProxy<NamedPipeClientStrea
 {
     private static new readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<GodotRuntimeExecutor>();
 
-    public GodotRuntimeExecutor()
-        : base(new NamedPipeClientStream(".", PIPE_NAME, PipeDirection.InOut, PipeOptions.Asynchronous, TokenImpersonationLevel.Impersonation), Logger)
+    public GodotRuntimeExecutor(string pipeName)
+        : base(new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous, TokenImpersonationLevel.Impersonation), Logger)
     {
     }
 
@@ -42,7 +42,6 @@ internal sealed class GodotRuntimeExecutor : InOutPipeProxy<NamedPipeClientStrea
     {
         try
         {
-            Logger.LogInfo("Starting GodotRuntimeExecutor");
             await Proxy
                 .ConnectAsync(10000)
                 .ConfigureAwait(false);
@@ -58,7 +57,6 @@ internal sealed class GodotRuntimeExecutor : InOutPipeProxy<NamedPipeClientStrea
     {
         try
         {
-            Logger.LogInfo("Stop GodotRuntimeExecutor");
             _ = await ExecuteCommand(new TerminateGodotInstanceCommand(), new NoInteractTestEventListener(), CancellationToken.None)
                 .ConfigureAwait(true);
 

--- a/Api/src/core/logging/GodotLogger.cs
+++ b/Api/src/core/logging/GodotLogger.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 Mike Schulze
 // MIT License - See LICENSE file in the repository root for full license text
 
-namespace GdUnit4.Core.Runners;
+namespace GdUnit4.Core.Logging;
 
 using Api;
 

--- a/Api/src/core/runners/DefaultTestRunner.cs
+++ b/Api/src/core/runners/DefaultTestRunner.cs
@@ -3,9 +3,7 @@
 
 namespace GdUnit4.Core.Runners;
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
 
 using Api;
 
@@ -36,7 +34,7 @@ internal sealed class DefaultTestRunner : BaseTestRunner
 
     public new void RunAndWait(List<TestSuiteNode> testSuiteNodes, ITestEventListener eventListener, CancellationToken cancellationToken)
     {
-        Logger.LogInfo("======== Running GdUnit4 Default Test Runner ========");
+        Logger.LogInfo("Starting DefaultTestRunner");
         base.RunAndWait(testSuiteNodes, eventListener, cancellationToken);
     }
 }

--- a/Api/src/core/runners/GdUnit4TestRunnerSceneCore.cs
+++ b/Api/src/core/runners/GdUnit4TestRunnerSceneCore.cs
@@ -3,12 +3,13 @@
 
 namespace GdUnit4.Core.Runners;
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 using Api;
 
 using Godot;
+
+using Logging;
 
 /// <summary>
 ///     The GdUnit4Net test runner scene.
@@ -41,7 +42,7 @@ public partial class GdUnit4TestRunnerSceneCore : SceneTree
         public TestRunner()
         {
             Logger = new GodotLogger();
-            Server = new GodotGdUnit4RestServer(Logger);
+            Server = new GodotGdUnit4RestServer(Logger, ResolvePipeName());
         }
 
         private ITestEngineLogger Logger { get; }
@@ -56,6 +57,15 @@ public partial class GdUnit4TestRunnerSceneCore : SceneTree
         {
             if (what == NotificationPredelete)
                 Server.Stop();
+        }
+
+        private static string ResolvePipeName()
+        {
+            var args = OS.GetCmdlineArgs();
+            var index = Array.IndexOf(args, "--pipe-name");
+            if (index < 0 || index >= args.Length - 1)
+                throw new InvalidOperationException("Missing required '--pipe-name' argument.");
+            return args[index + 1];
         }
     }
 }

--- a/Api/src/core/runners/GodotGdUnit4RestServer.cs
+++ b/Api/src/core/runners/GodotGdUnit4RestServer.cs
@@ -18,8 +18,8 @@ internal sealed class GodotGdUnit4RestServer : InOutPipeProxy<NamedPipeServerStr
 {
     private readonly SemaphoreSlim processLock = new(1, 1);
 
-    public GodotGdUnit4RestServer(ITestEngineLogger logger)
-        : base(new NamedPipeServerStream(PIPE_NAME, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous), logger)
+    public GodotGdUnit4RestServer(ITestEngineLogger logger, string pipeName)
+        : base(new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous), logger)
     {
     }
 

--- a/Api/src/core/runners/GodotRuntimeTestRunner.cs
+++ b/Api/src/core/runners/GodotRuntimeTestRunner.cs
@@ -32,18 +32,23 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
     internal const string TEMP_TEST_RUNNER_DIR = "gdunit4_testadapter_v5";
 
     private static readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<GodotRuntimeTestRunner>();
+    private readonly string pipeName;
 
+    private readonly ScopeLogger scope;
     private readonly TestEngineSettings settings;
     private Process? process;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="GodotRuntimeTestRunner" /> class.
     /// </summary>
+    /// <param name="assemblyId">Assembly identifier used to create a unique pipe name, preventing collisions when running multiple assemblies in parallel.</param>
     /// <param name="debuggerFramework">Framework for debugging support.</param>
     /// <param name="settings">Test engine configuration settings.</param>
-    internal GodotRuntimeTestRunner(IDebuggerFramework debuggerFramework, TestEngineSettings settings)
-        : base(new GodotRuntimeExecutor(), settings)
+    internal GodotRuntimeTestRunner(string assemblyId, IDebuggerFramework debuggerFramework, TestEngineSettings settings)
+        : base(new GodotRuntimeExecutor($"gdunit4-{assemblyId}"), settings)
     {
+        pipeName = $"gdunit4-{assemblyId}";
+        scope = LoggerFactory.Instance.GetScope() ?? new ScopeLogger(Logger, assemblyId);
         this.settings = settings;
         DebuggerFramework = debuggerFramework;
     }
@@ -77,16 +82,6 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
         }
     }
 
-    private DataReceivedEventHandler StdErrorProcessor => (_, args) =>
-    {
-        var message = args.Data?.Trim();
-        if (string.IsNullOrEmpty(message))
-            return;
-
-        // we do log errors to stdout otherwise running `dotnet test` from console will fail with exit code 1
-        Logger.LogInfo($":stderr: {message}");
-    };
-
     public override void Cancel()
     {
         base.Cancel();
@@ -111,10 +106,10 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
 
             if (!ReCompileGodotProject(Environment.CurrentDirectory, godotBinary))
                 return;
-            Logger.LogInfo("======== Running GdUnit4 Godot Runtime Test Runner ========");
+            Logger.LogInfo("Starting GodotRuntimeTestRunner");
 
             var processStartInfo =
-                new ProcessStartInfo(godotBinary, BuildGodotArguments(settings))
+                new ProcessStartInfo(godotBinary, BuildGodotArguments())
                 {
                     StandardOutputEncoding = Encoding.Default,
                     RedirectStandardOutput = true,
@@ -126,6 +121,8 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
                     WorkingDirectory = Environment.CurrentDirectory
                 };
 
+            Logger.LogInfo($"Arguments: {processStartInfo.Arguments}");
+
             if (DebuggerFramework.IsDebugProcess)
                 process = DebuggerFramework.LaunchProcessWithDebuggerAttached(processStartInfo);
             else
@@ -135,16 +132,10 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
                     StartInfo = processStartInfo,
                     EnableRaisingEvents = true
                 };
-                process.OutputDataReceived += (_, args) =>
-                {
-                    var message = args.Data?.Trim();
-                    if (string.IsNullOrEmpty(message))
-                        return;
-
-                    Logger.LogInfo($":stdout: {message}");
-                };
-                process.ErrorDataReceived += StdErrorProcessor;
-                process.Exited += ExitHandler("GdUnit4 Godot Runtime Test Runner");
+                var godotLogger = scope.WithSource("Godot");
+                process.OutputDataReceived += godotLogger.Output;
+                process.ErrorDataReceived += godotLogger.Error;
+                process.Exited += ExitHandler("GodotRuntimeTestRunner");
                 _ = process.Start();
                 process.BeginErrorReadLine();
                 process.BeginOutputReadLine();
@@ -164,7 +155,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
             // If the process not finished until 10 retries, we kill it manually
             if (!process.HasExited)
             {
-                Logger.LogInfo("GdUnit4 Godot Runtime Test Runner is not terminated, force process kill.");
+                Logger.LogWarning("GodotRuntimeTestRunner is not terminated, force process kill.");
                 process.Kill(true);
             }
 
@@ -276,7 +267,8 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
         if (File.Exists(sceneRunnerSource))
             return true;
 
-        Logger.LogInfo($"Installing GdUnit4TestRunnerScene at {destinationFolderPath}");
+        Logger.LogInfo("Installing GdUnit4TestRunner at");
+        Logger.LogInfo(destinationFolderPath);
 
         var assembly = Assembly.GetExecutingAssembly();
         using var stream = assembly.GetManifestResourceStream("GdUnit4.src.core.runners.GdUnit4TestRunnerSceneTemplate.cs");
@@ -310,23 +302,18 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
                 WorkingDirectory = workingDirectory
             };
 
-            Logger.LogInfo($"Working dir {workingDirectory}");
-            Logger.LogInfo($"Rebuild Godot Project ... {godotBinary} {processStartInfo.Arguments}");
+            Logger.LogInfo($"Set working dir {workingDirectory}");
+            Logger.LogInfo("Rebuilding Godot Project ...");
+            Logger.LogInfo($"{godotBinary} {processStartInfo.Arguments}");
             compileProcess.StartInfo = processStartInfo;
             compileProcess.EnableRaisingEvents = true;
-            compileProcess.OutputDataReceived += (_, args) =>
-            {
-                var message = args.Data?.Trim();
-                if (string.IsNullOrEmpty(message))
-                    return;
-
-                Logger.LogInfo($":stdout: {message}");
-            };
-            compileProcess.ErrorDataReceived += StdErrorProcessor;
-            compileProcess.Exited += ExitHandler("Rebuild Godot Project");
+            var compileLogger = scope.WithSource("Godot");
+            compileProcess.OutputDataReceived += compileLogger.Output;
+            compileProcess.ErrorDataReceived += compileLogger.Error;
+            compileProcess.Exited += ExitHandler("Rebuilding Godot Project");
             if (!compileProcess.Start())
             {
-                Logger.LogError("Rebuild Godot Project fails on process start, exit ..");
+                Logger.LogError("Rebuilding Godot Project fails on process start, exit ..");
                 return false;
             }
 
@@ -346,6 +333,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
             // If the process has not finished within the timeout period, we kill it manually
             if (!compileProcess.HasExited)
             {
+                Logger.LogError("Godot compilation TIMEOUT");
                 Logger.LogError(
                     $"""
 
@@ -382,7 +370,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
         catch (Exception e)
 #pragma warning restore CA1031
         {
-            Logger.LogError($"Install GdUnit4 `TestRunner` fails with: {e.Message}\n {e.StackTrace}");
+            Logger.LogError($"Rebuilding Godot Project fails with: {e.Message}\n {e.StackTrace}");
 
             return false;
         }
@@ -392,8 +380,8 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
         }
     }
 
-    private static string BuildGodotArguments(TestEngineSettings testEngineSettings)
-        => $"--path . -d -s res://{TEMP_TEST_RUNNER_DIR}/GdUnit4TestRunnerScene.cs {testEngineSettings.Parameters}";
+    private string BuildGodotArguments()
+        => $"--path . -s res://{TEMP_TEST_RUNNER_DIR}/GdUnit4TestRunnerScene.cs {settings.Parameters} --pipe-name {pipeName}";
 
     private bool RunDotnetRestore(string workingDirectory)
     {
@@ -421,19 +409,9 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
             restoreProcess.StartInfo = processStartInfo;
             restoreProcess.EnableRaisingEvents = true;
 
-            restoreProcess.OutputDataReceived += (_, args) =>
-            {
-                var message = args.Data?.Trim();
-                if (!string.IsNullOrEmpty(message))
-                    Logger.LogInfo($":build: {message}");
-            };
-
-            restoreProcess.ErrorDataReceived += (_, args) =>
-            {
-                var message = args.Data?.Trim();
-                if (!string.IsNullOrEmpty(message))
-                    Logger.LogInfo($":stderr: {message}");
-            };
+            var dotnetLogger = scope.WithSource("dotnet");
+            restoreProcess.OutputDataReceived += dotnetLogger.Output;
+            restoreProcess.ErrorDataReceived += dotnetLogger.Error;
 
             if (!restoreProcess.Start())
             {
@@ -456,6 +434,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
             // If the process has not finished within the timeout period, we kill it manually
             if (!restoreProcess.HasExited)
             {
+                Logger.LogError($"`dotnet build` did not complete within the configured timeout of {settings.CompileProcessTimeout}ms.");
                 Logger.LogError(
                     $"""
 
@@ -497,20 +476,20 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
         catch (Exception ex)
 #pragma warning restore CA1031
         {
-            Logger.LogError($"Error running build restore: {ex.Message}");
+            Logger.LogError($"Error: restore: {ex.Message}");
             return false;
         }
     }
 
-    private EventHandler ExitHandler(string source = "") => (sender, _) =>
+    private EventHandler ExitHandler(string source) => (sender, _) =>
     {
         Console.Out.Flush();
         if (sender is Process p)
         {
             if (p.ExitCode == 0)
-                Logger.LogInfo($"{source} ends with exit code: {p.ExitCode}\n");
+                Logger.LogInfo($"{source} ends with exit code: {p.ExitCode}");
             else
-                Logger.LogError($"{source} ends with exit code: {p.ExitCode}\n");
+                Logger.LogError($"{source} ends with exit code: {p.ExitCode}");
         }
     };
 
@@ -522,8 +501,6 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
         {
             processToClose.CancelErrorRead();
             processToClose.CancelOutputRead();
-            processToClose.ErrorDataReceived -= StdErrorProcessor;
-            processToClose.Exited -= ExitHandler();
             processToClose.Dispose();
         }
 #pragma warning disable CA1031

--- a/Api/src/core/runners/InOutPipeProxy.cs
+++ b/Api/src/core/runners/InOutPipeProxy.cs
@@ -17,8 +17,6 @@ using Newtonsoft.Json;
 internal class InOutPipeProxy<TPipe> : IAsyncDisposable
     where TPipe : PipeStream
 {
-    protected const string PIPE_NAME = "gdunit4-message-pipe";
-
     protected InOutPipeProxy(TPipe pipe, ITestEngineLogger logger)
     {
         Logger = logger;

--- a/Example/ExampleProject.csproj
+++ b/Example/ExampleProject.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
         <!-- We only include here the MSTest framework to run tests mixed with MSTest assertions, but set it to private to prevent conflicts -->
         <PackageReference Include="MSTest.TestFramework" Version="3.10.4" ExcludeAssets="build;analyzers;native"/>
-        <PackageReference Include="gdUnit4.api" Version="5.1.0-rc3"/>
+        <PackageReference Include="gdUnit4.api" Version="5.1.0-rc4"/>
         <PackageReference Include="gdUnit4.test.adapter" Version="3.0.0"/>
         <PackageReference Include="gdUnit4.analyzers" Version="1.0.0">
             <PrivateAssets>none</PrivateAssets>

--- a/ProjectVersions.props
+++ b/ProjectVersions.props
@@ -2,7 +2,7 @@
   <!-- GdUnit4 Component Versions -->
   <PropertyGroup>
     <GdUnitAnalyzersVersion>1.0.0</GdUnitAnalyzersVersion>
-    <GdUnitAPIVersion>5.1.0-rc3</GdUnitAPIVersion>
+    <GdUnitAPIVersion>5.1.0-rc4</GdUnitAPIVersion>
     <GdUnitTestAdapterVersion>3.0.1</GdUnitTestAdapterVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
## Why
When multiple test assemblies are executed in parallel, all `GodotRuntimeTestRunner` instances shared the same hardcoded pipe name (`gdunit4-message-pipe`), causing IPC collisions and test failures under concurrent execution.

## What
- `GodotRuntimeExecutor` now accepts a `pipeName` parameter instead of using the hardcoded constant from `InOutPipeProxy`
- `GodotRuntimeTestRunner` takes an `assemblyId` and derives a unique pipe name (`gdunit4-{assemblyId}`) per assembly execution - `GdUnit4TestEngine` passes `assemblyId` (derived from the assembly file name) down to `GodotRuntimeTestRunner`, scoping both the log output and the pipe name to the assembly
- Process output/error handlers use `ScopeLogger.WithSource(...)` so all subprocess log lines are tagged with the assembly scope
- `GodotLogger` moved from `Runners` to `Logging` namespace