### PR TITLE
GD-443: Make Godot runtime connect timeout configurable

### DIFF
--- a/Api/src/api/TestEngineSettings.cs
+++ b/Api/src/api/TestEngineSettings.cs
@@ -79,5 +79,5 @@ public sealed class TestEngineSettings
     ///     Default value is 10000 milliseconds (10 seconds).
     ///     Set to a higher value for environments where the Godot host needs more time to start.
     /// </remarks>
-    public int RuntimeConnectTimeout { get; init; } = 10000;
+    public int GodotConnectTimeout { get; init; } = 10000;
 }

--- a/Api/src/api/TestEngineSettings.cs
+++ b/Api/src/api/TestEngineSettings.cs
@@ -69,4 +69,15 @@ public sealed class TestEngineSettings
     ///     Set to a higher value for projects that require more compilation time.
     /// </remarks>
     public int CompileProcessTimeout { get; init; } = 120000;
+
+    /// <summary>
+    ///     Gets the maximum duration allowed to connect to the Godot runtime host in milliseconds.
+    /// </summary>
+    /// <remarks>
+    ///     Applies when connecting to the launched Godot runtime host over a named pipe.
+    ///     After this timeout period expires, the connection attempt is aborted.
+    ///     Default value is 10000 milliseconds (10 seconds).
+    ///     Set to a higher value for environments where the Godot host needs more time to start.
+    /// </remarks>
+    public int RuntimeConnectTimeout { get; init; } = 10000;
 }

--- a/Api/src/core/execution/GodotRuntimeExecutor.cs
+++ b/Api/src/core/execution/GodotRuntimeExecutor.cs
@@ -33,17 +33,18 @@ internal sealed class GodotRuntimeExecutor : InOutPipeProxy<NamedPipeClientStrea
 {
     private static new readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<GodotRuntimeExecutor>();
 
-    public GodotRuntimeExecutor(string pipeName)
+    private readonly int connectTimeoutMs;
+
+    public GodotRuntimeExecutor(string pipeName, int connectTimeoutMs = 10000)
         : base(new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous, TokenImpersonationLevel.Impersonation), Logger)
-    {
-    }
+        => this.connectTimeoutMs = connectTimeoutMs;
 
     public async Task StartAsync()
     {
         try
         {
             await Proxy
-                .ConnectAsync(10000)
+                .ConnectAsync(connectTimeoutMs)
                 .ConfigureAwait(false);
         }
         catch (Exception e)

--- a/Api/src/core/execution/GodotRuntimeExecutor.cs
+++ b/Api/src/core/execution/GodotRuntimeExecutor.cs
@@ -33,18 +33,18 @@ internal sealed class GodotRuntimeExecutor : InOutPipeProxy<NamedPipeClientStrea
 {
     private static new readonly ITestEngineLogger Logger = LoggerFactory.GetLogger<GodotRuntimeExecutor>();
 
-    private readonly int connectTimeoutMs;
+    private readonly int connectTimeout;
 
-    public GodotRuntimeExecutor(string pipeName, int connectTimeoutMs = 10000)
+    public GodotRuntimeExecutor(string pipeName, int connectTimeout)
         : base(new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous, TokenImpersonationLevel.Impersonation), Logger)
-        => this.connectTimeoutMs = connectTimeoutMs;
+        => this.connectTimeout = connectTimeout;
 
     public async Task StartAsync()
     {
         try
         {
             await Proxy
-                .ConnectAsync(connectTimeoutMs)
+                .ConnectAsync(connectTimeout)
                 .ConfigureAwait(false);
         }
         catch (Exception e)

--- a/Api/src/core/runners/GodotRuntimeTestRunner.cs
+++ b/Api/src/core/runners/GodotRuntimeTestRunner.cs
@@ -45,7 +45,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
     /// <param name="debuggerFramework">Framework for debugging support.</param>
     /// <param name="settings">Test engine configuration settings.</param>
     internal GodotRuntimeTestRunner(string assemblyId, IDebuggerFramework debuggerFramework, TestEngineSettings settings)
-        : base(new GodotRuntimeExecutor($"gdunit4-{assemblyId}"), settings)
+        : base(new GodotRuntimeExecutor($"gdunit4-{assemblyId}", settings.RuntimeConnectTimeout), settings)
     {
         pipeName = $"gdunit4-{assemblyId}";
         scope = LoggerFactory.Instance.GetScope() ?? new ScopeLogger(Logger, assemblyId);

--- a/Api/src/core/runners/GodotRuntimeTestRunner.cs
+++ b/Api/src/core/runners/GodotRuntimeTestRunner.cs
@@ -45,7 +45,7 @@ internal sealed class GodotRuntimeTestRunner : BaseTestRunner
     /// <param name="debuggerFramework">Framework for debugging support.</param>
     /// <param name="settings">Test engine configuration settings.</param>
     internal GodotRuntimeTestRunner(string assemblyId, IDebuggerFramework debuggerFramework, TestEngineSettings settings)
-        : base(new GodotRuntimeExecutor($"gdunit4-{assemblyId}", settings.RuntimeConnectTimeout), settings)
+        : base(new GodotRuntimeExecutor($"gdunit4-{assemblyId}", settings.GodotConnectTimeout), settings)
     {
         pipeName = $"gdunit4-{assemblyId}";
         scope = LoggerFactory.Instance.GetScope() ?? new ScopeLogger(Logger, assemblyId);

--- a/TestAdapter/README.md
+++ b/TestAdapter/README.md
@@ -122,6 +122,9 @@ Create a `.runsettings` file in your solution root:
         
         <!-- Compilation timeout for large projects (milliseconds) -->
         <CompileProcessTimeout>20000</CompileProcessTimeout>
+        
+        <!-- Connect timeout to the Godot runtime host for slow or variable environments (milliseconds) -->
+        <GodotConnectTimeout>10000</GodotConnectTimeout>
     </GdUnit4>
 </RunSettings>
 ```
@@ -134,6 +137,7 @@ Create a `.runsettings` file in your solution root:
 | `DisplayName`           | Test name format in results                       | `SimpleName` | `FullyQualifiedName`     |
 | `CaptureStdOut`         | Capture test output in results                    | `false`      | `true`                   |
 | `CompileProcessTimeout` | Godot compilation timeout (ms)                    | `20000`      | `30000`                  |
+| `GodotConnectTimeout`   | Godot runtime host connect timeout (ms)           | `10000`      | `60000`                  |
 
 ### Using .runsettings
 

--- a/TestAdapter/src/GdUnit4TestExecutor.cs
+++ b/TestAdapter/src/GdUnit4TestExecutor.cs
@@ -108,7 +108,8 @@ public class GdUnit4TestExecutor : ITestExecutor2, IDisposable
             SessionTimeout = (int)(runConfiguration.TestSessionTimeout == 0
                 ? DEFAULT_SESSION_TIMEOUT
                 : runConfiguration.TestSessionTimeout),
-            CompileProcessTimeout = settings.CompileProcessTimeout
+            CompileProcessTimeout = settings.CompileProcessTimeout,
+            RuntimeConnectTimeout = settings.RuntimeConnectTimeout
         };
 
         testEngine = ITestEngine.GetInstance(engineSettings, Log);

--- a/TestAdapter/src/GdUnit4TestExecutor.cs
+++ b/TestAdapter/src/GdUnit4TestExecutor.cs
@@ -109,7 +109,7 @@ public class GdUnit4TestExecutor : ITestExecutor2, IDisposable
                 ? DEFAULT_SESSION_TIMEOUT
                 : runConfiguration.TestSessionTimeout),
             CompileProcessTimeout = settings.CompileProcessTimeout,
-            RuntimeConnectTimeout = settings.RuntimeConnectTimeout
+            GodotConnectTimeout = settings.GodotConnectTimeout
         };
 
         testEngine = ITestEngine.GetInstance(engineSettings, Log);

--- a/TestAdapter/src/settings/GdUnit4Settings.cs
+++ b/TestAdapter/src/settings/GdUnit4Settings.cs
@@ -38,7 +38,7 @@ public enum DisplayNameOptions
 ///     &lt;CaptureStdOut&gt;true&lt;/CaptureStdOut&gt;
 ///     &lt;Parameters&gt;--verbose --headless&lt;/Parameters&gt;
 ///     &lt;CompileProcessTimeout&gt;30000&lt;/CompileProcessTimeout&gt;
-///     &lt;RuntimeConnectTimeout&gt;10000&lt;/RuntimeConnectTimeout&gt;
+///     &lt;GodotConnectTimeout&gt;10000&lt;/GodotConnectTimeout&gt;
 ///   &lt;/GdUnit4&gt;
 /// &lt;/RunSettings&gt;
 /// </code>
@@ -144,7 +144,7 @@ public class GdUnit4Settings : TestRunSettings
     ///     before running tests that require the Godot runtime. Increase it for environments where the
     ///     Godot host needs more time to start.
     /// </remarks>
-    public int RuntimeConnectTimeout { get; init; } = 10000;
+    public int GodotConnectTimeout { get; init; } = 10000;
 
     /// <summary>
     ///     Converts the current settings instance to an XML element for inclusion in .runsettings files.

--- a/TestAdapter/src/settings/GdUnit4Settings.cs
+++ b/TestAdapter/src/settings/GdUnit4Settings.cs
@@ -38,6 +38,7 @@ public enum DisplayNameOptions
 ///     &lt;CaptureStdOut&gt;true&lt;/CaptureStdOut&gt;
 ///     &lt;Parameters&gt;--verbose --headless&lt;/Parameters&gt;
 ///     &lt;CompileProcessTimeout&gt;30000&lt;/CompileProcessTimeout&gt;
+///     &lt;RuntimeConnectTimeout&gt;10000&lt;/RuntimeConnectTimeout&gt;
 ///   &lt;/GdUnit4&gt;
 /// &lt;/RunSettings&gt;
 /// </code>
@@ -46,6 +47,7 @@ public enum DisplayNameOptions
 ///     - Standard output capture for debugging purposes
 ///     - Additional parameters passed to the Godot engine during test execution
 ///     - Compilation timeout for projects that require extended build times
+///     - Connect timeout for the Godot runtime host on slow or variable environments
 ///     These settings are loaded by <see cref="GdUnit4SettingsProvider" /> during test discovery and execution.
 /// </remarks>
 [XmlRoot(RUN_SETTINGS_XML_NODE)]
@@ -130,6 +132,19 @@ public class GdUnit4Settings : TestRunSettings
     /// </code>
     /// </example>
     public int CompileProcessTimeout { get; init; } = 120000;
+
+    /// <summary>
+    ///     Gets the maximum duration allowed to connect to the Godot runtime host in milliseconds.
+    /// </summary>
+    /// <value>
+    ///     The timeout value in milliseconds. Default is 10000 milliseconds (10 seconds).
+    /// </value>
+    /// <remarks>
+    ///     This timeout applies when connecting to the launched Godot runtime host over a named pipe
+    ///     before running tests that require the Godot runtime. Increase it for environments where the
+    ///     Godot host needs more time to start.
+    /// </remarks>
+    public int RuntimeConnectTimeout { get; init; } = 10000;
 
     /// <summary>
     ///     Converts the current settings instance to an XML element for inclusion in .runsettings files.


### PR DESCRIPTION
# Why
Tests that require the Godot runtime launch a Godot host and connect to it over a named pipe with a hardcoded 10s timeout. On slow or variable environments the host can need longer to boot and create the pipe server, so the connect times out and the runtime tests silently fall back to running only the non-runtime tests.

# What
- Add `RuntimeConnectTimeout` to `TestEngineSettings` (default 10000ms)
- Parse `<RuntimeConnectTimeout>` from the `<GdUnit4>` runsettings section
- Thread it through `GodotRuntimeTestRunner` into `GodotRuntimeExecutor` and use it for the `ConnectAsync` call

Defaults to the previous 10000ms, so behavior is unchanged unless set.

Addresses #443