### PR TITLE
GD-446:  Suppress non-16KB-aligned native libs from Android export publish output

### DIFF
--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -116,3 +116,31 @@ jobs:
           fail-on-error: 'false'
           fail-on-empty: 'false'
           use-actions-summary: 'false'
+
+      # publish Example Tests results
+      - name: Download Example tests artifacts
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: artifact_example_tests_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: godot-gdunit-labs/gdUnit4Net
+          run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
+
+      - name: Publish Example Test Results
+        uses: dorny/test-reporter@v3.0.0
+        with:
+          name: report_example_tests_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
+          path: './home/runner/work/gdUnit4Net/gdUnit4Net/Example/TestResults/test-result.trx'
+          reporter: dotnet-trx
+          fail-on-error: 'false'
+          fail-on-empty: 'false'
+          use-actions-summary: 'false'
+
+      - name: Publish Code Coverage Summary
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: './home/runner/work/gdUnit4Net/gdUnit4Net/Example/TestResults/**/*.cobertura.xml'
+          badge: true
+          format: markdown
+          output: both
+          hide-complexity: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -216,3 +216,24 @@ jobs:
           validate_section '<ResultSummary' '<ResultSummary outcome="Failed">'
           validate_section '<ResultSummary' '<Counters total="39" executed="39" passed="38" failed="1" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />'
           echo "All tests passes."
+
+      - name: Validate Code Coverage Report
+        shell: bash
+        run: |
+          coverage_file=$(find ./Example/TestResults -name "*.cobertura.xml" | head -1)
+          if [ -z "$coverage_file" ]; then
+            echo "Code coverage validation failed: no cobertura.xml found in ./Example/TestResults"
+            exit 1
+          fi
+          lines_covered=$(grep -oE 'lines-covered="[0-9]+"' "$coverage_file" | grep -oE '[0-9]+' | head -1)
+          if [ -z "$lines_covered" ] || [ "$lines_covered" -eq 0 ]; then
+            echo "Code coverage validation failed: lines-covered is 0 or missing in $coverage_file"
+            exit 1
+          fi
+          echo "Code coverage validation passed: $coverage_file (lines-covered=$lines_covered)"
+
+      - name: "Upload Unit Test Reports"
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/upload-test-report
+        with:
+          report-name: example_tests_Godot${{ inputs.godot-version }}-${{ inputs.godot-status }}

--- a/Example/.runsettings
+++ b/Example/.runsettings
@@ -3,10 +3,20 @@
     <RunConfiguration>
         <MaxCpuCount>1</MaxCpuCount>
         <ResultsDirectory>./TestResults</ResultsDirectory>
-        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <TestSessionTimeout>180000</TestSessionTimeout>
         <TreatNoTestsAsError>true</TreatNoTestsAsError>
     </RunConfiguration>
+
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0">
+                <Configuration>
+                    <Format>cobertura</Format>
+                </Configuration>
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
 
     <LoggerRunSettings>
         <Loggers>

--- a/Example/.runsettings-ci
+++ b/Example/.runsettings-ci
@@ -3,7 +3,7 @@
     <RunConfiguration>
         <MaxCpuCount>1</MaxCpuCount>
         <ResultsDirectory>./TestResults</ResultsDirectory>
-        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <TestSessionTimeout>180000</TestSessionTimeout>
         <TreatNoTestsAsError>true</TreatNoTestsAsError>
     </RunConfiguration>
@@ -27,6 +27,16 @@
             </Logger>
         </Loggers>
     </LoggerRunSettings>
+
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0">
+                <Configuration>
+                    <Format>cobertura</Format>
+                </Configuration>
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
 
     <GdUnit4>
         <!-- Additonal Godot runtime parameters-->

--- a/Example/ExampleProject.csproj
+++ b/Example/ExampleProject.csproj
@@ -23,7 +23,7 @@
         <!-- We only include here the MSTest framework to run tests mixed with MSTest assertions, but set it to private to prevent conflicts -->
         <PackageReference Include="MSTest.TestFramework" Version="3.10.4" ExcludeAssets="build;analyzers;native"/>
         <PackageReference Include="gdUnit4.api" Version="5.1.0-rc5"/>
-        <PackageReference Include="gdUnit4.test.adapter" Version="3.1.0"/>
+        <PackageReference Include="gdUnit4.test.adapter" Version="3.1.1"/>
         <PackageReference Include="gdUnit4.analyzers" Version="1.0.0">
             <PrivateAssets>none</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ProjectVersions.props
+++ b/ProjectVersions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GdUnitAnalyzersVersion>1.0.0</GdUnitAnalyzersVersion>
     <GdUnitAPIVersion>5.1.0-rc5</GdUnitAPIVersion>
-    <GdUnitTestAdapterVersion>3.1.0</GdUnitTestAdapterVersion>
+    <GdUnitTestAdapterVersion>3.1.1</GdUnitTestAdapterVersion>
   </PropertyGroup>
 
   <!-- Godot Configuration -->

--- a/TestAdapter/GdUnit4TestAdapter.csproj
+++ b/TestAdapter/GdUnit4TestAdapter.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <Title>gdUnit4 TestAdapter</Title>
     <Version>$(GdUnitTestAdapterVersion)</Version>
     <Description>

--- a/TestAdapter/GdUnit4TestAdapter.csproj
+++ b/TestAdapter/GdUnit4TestAdapter.csproj
@@ -67,6 +67,10 @@
     <None Include="../LICENSE" Pack="true" PackagePath="/"/>
     <None Include="../CONTRIBUTING.md" Pack="true" PackagePath="/"/>
     <None Include="../icon.png" Pack="true" PackagePath="/"/>
+    <!-- Override Microsoft.CodeCoverage's CopyTraceDataCollectorArtifacts target to prevent
+         non-16KB-aligned .so files from being included in the publish output.
+         See build/gdUnit4.test.adapter.targets for details. -->
+    <None Include="build/gdUnit4.test.adapter.targets" Pack="true" PackagePath="build/"/>
   </ItemGroup>
 
 </Project>

--- a/TestAdapter/ReleaseNotes.txt
+++ b/TestAdapter/ReleaseNotes.txt
@@ -1,3 +1,11 @@
+v3.1.1
+* GD-448: Fix non-16KB-aligned native libs being included in Android export publish output.
+          A bundled `.targets` file now suppresses Microsoft.CodeCoverage's `CopyTraceDataCollectorArtifacts`
+          target so that `libInstrumentationEngine.so` and `libCoverageInstrumentationMethod.so` are not
+          copied into the `dotnet publish` output. This prevents Google Play and Android Studio from
+          rejecting AABs built for Android 15+ (API 35) devices. Code coverage collection during test
+          runs is unaffected.
+
 v3.1.0
 * GD-446: Fixing nuget packaging by exclude `Microsoft.NET.Test.Sdk`, `coverlet.collector` and `Godot.SourceGenerators`
           Microsoft.NET.Test.Sdk, coverlet.collector and Godot.SourceGenerators are no longer transitively exported by gdUnit4.test.adapter.

--- a/TestAdapter/build/gdUnit4.test.adapter.targets
+++ b/TestAdapter/build/gdUnit4.test.adapter.targets
@@ -1,0 +1,27 @@
+<!--
+  gdUnit4.test.adapter.targets
+
+  Overrides Microsoft.CodeCoverage's CopyTraceDataCollectorArtifacts target, which is defined
+  in Microsoft.CodeCoverage.targets (AfterTargets="ComputeFilesToPublish") and copies its entire
+  build/ folder — including libInstrumentationEngine.so and libCoverageInstrumentationMethod.so —
+  into the dotnet publish output.
+
+  When building a Godot Android project, Godot's export plugin picks up every .so from the
+  publish output and copies it into android/build/libs/release/arm64-v8a/, where Gradle packages
+  it into the final AAB. Those two pre-built Microsoft binaries lack the 16KB ELF segment
+  alignment required for Android 15+ (API 35) devices, causing Google Play and Android Studio
+  to reject the bundle.
+
+  These files are developer diagnostic tools (CLR profiler / code coverage instrumentation)
+  with no role in a shipped Android application. Suppressing the copy is safe for all Godot
+  mobile (and desktop) consumers of this package.
+
+  Because NuGet imports package .targets files in dependency-graph order (transitive
+  dependencies first), this file is imported after Microsoft.CodeCoverage.targets, so the
+  empty target defined here wins.
+-->
+<Project>
+  <Target Name="CopyTraceDataCollectorArtifacts" AfterTargets="ComputeFilesToPublish">
+    <!-- Intentionally empty: suppresses non-16KB-aligned native libs from publish output. -->
+  </Target>
+</Project>


### PR DESCRIPTION
## Why

When a Godot C# project using `gdUnit4.test.adapter` is exported for Android, the final AAB contains two pre-built Microsoft native libraries that violate the **16KB ELF segment alignment** requirement for Android 15+ (API 35):

- `base/lib/arm64-v8a/libInstrumentationEngine.so`
- `base/lib/arm64-v8a/libCoverageInstrumentationMethod.so`

This causes Google Play and Android Studio to reject the bundle with:
```
PT_GNU_RELRO ... RELRO is not a suffix and its end is not 16 KB aligned
```

## Root Cause

`Microsoft.CodeCoverage` (a transitive dependency via `Microsoft.NET.Test.Sdk`) ships a MSBuild targets file containing this target:

```xml
<Target Name="CopyTraceDataCollectorArtifacts" AfterTargets="ComputeFilesToPublish">
  <ItemGroup>
    <TraceDataCollectorArtifacts Include="$(MSBuildThisFileDirectory)\**\*.*" />
  </ItemGroup>
  <Copy SourceFiles="@(TraceDataCollectorArtifacts)" DestinationFolder="$(PublishDir)%(RecursiveDir)" />
</Target>
```

This blindly copies **everything** from the package's `build/` folder — including Linux/macOS `.so` files — into the `dotnet publish` output. Godot's Android export plugin then copies all `.so` files from the publish output into `android/build/libs/release/arm64-v8a/`, where Gradle packages them into the final AAB.

Setting `<PrivateAssets>all</PrivateAssets>` on the `Microsoft.NET.Test.Sdk` reference does **not** suppress this: MSBuild targets in `build/` folders always execute in the consuming project regardless of `PrivateAssets`.

## What

Add `build/gdUnit4.test.adapter.targets` to the package. NuGet automatically imports `{packageId}.targets` from a package's `build/` folder, and since the adapter sits higher in the dependency graph than `Microsoft.CodeCoverage`, its targets file is imported **after** `Microsoft.CodeCoverage.targets` — overriding the problematic target with an empty body.

```xml
<Target Name="CopyTraceDataCollectorArtifacts" AfterTargets="ComputeFilesToPublish">
  <!-- Intentionally empty: suppresses non-16KB-aligned native libs from publish output. -->
</Target>
```

Consumers get the fix automatically with no changes to their own project — no `Directory.Build.targets` workaround required.

## Testing

Verified on a Godot 4.6.3 C# Android project:
- Before fix: `libInstrumentationEngine.so` and `libCoverageInstrumentationMethod.so` present in `dotnet publish` output and packaged into the AAB
- After fix: neither file appears in the publish output or the exported AAB